### PR TITLE
 Include dependencies graph in the `Metadata`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_metadata"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 repository = "https://github.com/oli-obk/cargo_metadata"
 description = "structured access to the output of `cargo metadata`"

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -1,8 +1,9 @@
 extern crate cargo_metadata;
 
 #[test]
-fn foo() {
+fn metadata() {
     let metadata = cargo_metadata::metadata(None).unwrap();
+
     assert_eq!(metadata.packages[0].name, "cargo_metadata");
     assert_eq!(metadata.packages[0].targets.len(), 2);
 
@@ -13,4 +14,21 @@ fn foo() {
     assert_eq!(metadata.packages[0].targets[1].name, "selftest");
     assert_eq!(metadata.packages[0].targets[1].kind[0], "test");
     assert_eq!(metadata.packages[0].targets[1].crate_types[0], "bin");
+}
+
+#[test]
+fn metadata_deps() {
+    let metadata = cargo_metadata::metadata_deps(None, true).unwrap();
+    let this = metadata.packages.iter().find(|package| package.name == "cargo_metadata").expect("Did not find ourselves");
+
+    assert_eq!(this.name, "cargo_metadata");
+    assert_eq!(this.targets.len(), 2);
+
+    assert_eq!(this.targets[0].name, "cargo_metadata");
+    assert_eq!(this.targets[0].kind[0], "lib");
+    assert_eq!(this.targets[0].crate_types[0], "lib");
+
+    assert_eq!(this.targets[1].name, "selftest");
+    assert_eq!(this.targets[1].kind[0], "test");
+    assert_eq!(this.targets[1].crate_types[0], "bin");
 }


### PR DESCRIPTION
I plan to use this for https://github.com/Manishearth/rust-clippy/issues/1797.