### PR TITLE
Ergonomic improvements and minor refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "cargo_metadata"
-version = "0.2.3"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
-repository = "https://github.com/oli-obk/cargo_metadata"
 description = "structured access to the output of `cargo metadata`"
 license = "MIT"
-
+name = "cargo_metadata"
+repository = "https://github.com/oli-obk/cargo_metadata"
+version = "0.2.3"
 [dependencies]
+error-chain = "0.10.0"
 serde = "1.0.2"
-serde_json = "1.0.1"
 serde_derive = "1.0.2"
+serde_json = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ license = "MIT"
 name = "cargo_metadata"
 repository = "https://github.com/oli-obk/cargo_metadata"
 version = "0.2.3"
+
 [dependencies]
 error-chain = "0.10.0"
-serde = "1.0.2"
-serde_derive = "1.0.2"
-serde_json = "1.0.1"
+serde = "1.0.11"
+serde_derive = "1.0.11"
+serde_json = "1.0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,18 @@
 //!
 //! ```rust
 //! # extern crate cargo_metadata;
-//! let manifest_path_arg = std::env::args().skip(2).find(|val| val.starts_with("--manifest-path="));
+//! let manifest_path_arg = std::env::args()
+//!     .skip(2)
+//!     .find(|val| val.starts_with("--manifest-path="));
 //! let metadata = cargo_metadata::metadata(manifest_path_arg.as_ref().map(AsRef::as_ref)).unwrap();
 //! ```
 
-#[macro_use] extern crate error_chain;
+#[macro_use]
+extern crate error_chain;
 extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
-#[macro_use] extern crate serde_derive;
 
 use std::collections::HashMap;
 use std::env;
@@ -19,7 +23,7 @@ use std::process::Command;
 use std::str::from_utf8;
 
 use errors::*;
-pub use errors::{Result, Error};
+pub use errors::{Error, Result};
 
 mod errors {
     // Create the Error, ErrorKind, ResultExt, and Result types
@@ -132,7 +136,8 @@ pub fn metadata_deps(manifest_path_arg: Option<&str>, deps: bool) -> Result<Meta
     if let Some(manifest_path) = manifest_path_arg {
         cmd.args(&["--manifest-path", manifest_path]);
     }
-    let output = cmd.output().chain_err(|| "Failed to execute `cargo metadata`")?;
+    let output = cmd.output()
+        .chain_err(|| "Failed to execute `cargo metadata`")?;
     let stdout = from_utf8(&output.stdout).chain_err(|| "`cargo metadata` output not valid UTF8")?;
     let meta = serde_json::from_str(stdout).chain_err(|| "`cargo metadata` output not valid JSON")?;
     Ok(meta)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,9 @@ pub fn metadata_deps(manifest_path_arg: Option<&str>, deps: bool) -> Result<Meta
         cmd.arg("--no-deps");
     }
 
-    cmd.arg("--format-version").arg("1");
-    if let Some(mani) = manifest_path_arg {
-        cmd.arg(mani);
+    cmd.args(&["--format-version", "1"]);
+    if let Some(manifest_path) = manifest_path_arg {
+        cmd.args(&["--manifest-path", manifest_path]);
     }
     let output = cmd.output().chain_err(|| "Failed to execute `cargo metadata`")?;
     let stdout = from_utf8(&output.stdout).chain_err(|| "`cargo metadata` output not valid UTF8")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,15 +78,37 @@ pub struct Package {
     pub manifest_path: String,
 }
 
+#[derive(PartialEq, Clone, Debug, Copy, Deserialize)]
+/// Dependencies can come in three kinds
+pub enum DependencyKind {
+    #[serde(rename = "normal")]
+    /// The 'normal' kind
+    Normal,
+    #[serde(rename = "dev")]
+    /// Those used in tests only
+    Development,
+    #[serde(rename = "build")]
+    /// Those used in build scripts only
+    Build,
+}
+
+impl Default for DependencyKind {
+    fn default() -> DependencyKind {
+        DependencyKind::Normal
+    }
+}
+
 #[derive(Clone, Deserialize, Debug)]
 /// A dependency of the main crate
 pub struct Dependency {
     /// Name as given in the `Cargo.toml`
     pub name: String,
     source: Option<String>,
-    /// Whether this is required or optional
+    /// The required version
     pub req: String,
-    kind: Option<String>,
+    #[serde(default)]
+    pub kind: Option<DependencyKind>,
+    /// Whether this is required or optional
     optional: bool,
     uses_default_features: bool,
     features: Vec<String>,
@@ -100,7 +122,7 @@ pub struct Target {
     pub name: String,
     /// Kind of target ("bin", "example", "test", "bench", "lib")
     pub kind: Vec<String>,
-    /// Almost the same as `kind`, except when an example is a library instad of an executable.
+    /// Almost the same as `kind`, except when an example is a library instead of an executable.
     /// In that case `crate_types` contains things like `rlib` and `dylib` while `kind` is `example`
     #[serde(default)]
     pub crate_types: Vec<String>,

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -19,7 +19,11 @@ fn metadata() {
 #[test]
 fn metadata_deps() {
     let metadata = cargo_metadata::metadata_deps(Some("Cargo.toml"), true).unwrap();
-    let this = metadata.packages.iter().find(|package| package.name == "cargo_metadata").expect("Did not find ourselves");
+    let this = metadata
+        .packages
+        .iter()
+        .find(|package| package.name == "cargo_metadata")
+        .expect("Did not find ourselves");
 
     assert_eq!(this.name, "cargo_metadata");
     assert_eq!(this.targets.len(), 2);

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -18,7 +18,7 @@ fn metadata() {
 
 #[test]
 fn metadata_deps() {
-    let metadata = cargo_metadata::metadata_deps(None, true).unwrap();
+    let metadata = cargo_metadata::metadata_deps(Some("Cargo.toml"), true).unwrap();
     let this = metadata.packages.iter().find(|package| package.name == "cargo_metadata").expect("Did not find ourselves");
 
     assert_eq!(this.name, "cargo_metadata");


### PR DESCRIPTION
This PR does several things:
* Use `error_chain` for errors - #11 
* Add/fix support for providing manifest path
* Expose `Dependency`'s `kind` field
* Run the latest rustfmt-nightly

(happy to split up if that would make life easier).