### PR TITLE
Use strongly-typed version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
+[dependencies.semver]
+features = ["serde"]
+version = "0.8"
+
 [dev-dependencies]
 clap = "2.26.0"
 docopt = "0.8.1"

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,6 +1,7 @@
 //! This module contains `Dependency` and the types/functions it uses for deserialization.
 
 use serde::{Deserialize, Deserializer};
+use semver::VersionReq;
 
 #[derive(PartialEq, Clone, Debug, Copy, Deserialize)]
 /// Dependencies can come in three kinds
@@ -37,7 +38,7 @@ pub struct Dependency {
     pub name: String,
     source: Option<String>,
     /// The required version
-    pub req: String,
+    pub req: VersionReq,
     /// The kind of dependency this is
     #[serde(deserialize_with = "parse_dependency_kind")]
     pub kind: DependencyKind,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@
 
 #[macro_use]
 extern crate error_chain;
+extern crate semver;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -37,4 +37,13 @@ fn metadata_deps() {
     assert_eq!(this.targets[1].name, "selftest");
     assert_eq!(this.targets[1].kind[0], "test");
     assert_eq!(this.targets[1].crate_types[0], "bin");
+
+    let dependencies = &this.dependencies;
+
+    let serde = dependencies
+        .iter()
+        .find(|dep| dep.name == "serde")
+        .expect("Did not find serde dependency");
+
+    assert_eq!(serde.kind, cargo_metadata::DependencyKind::Normal);
 }


### PR DESCRIPTION
`semver` now allows deserialization of `VersionReq`, so we can use that
in `Dependency` (instead of a plain `String`).

Finishes solving #12