### PR TITLE
Use doc attributes for foreign links

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,9 @@
 //! Create the `Error`, `ErrorKind`, `ResultExt`, and `Result` types
-#![allow(missing_docs)] // see https://github.com/rust-lang-nursery/error-chain/issues/63
 
 error_chain!{
     foreign_links {
-        // Error during execution of `cargo metadata`
-        Io(::std::io::Error);
-        // Output of `cargo metadata` was not valid utf8
-        Utf8(::std::str::Utf8Error);
-        // Deserialization error (structure of json did not match expected structure)
-        Json(::serde_json::Error);
+        Io(::std::io::Error) #[doc = "Error during execution of `cargo metadata`"];
+        Utf8(::std::str::Utf8Error) #[doc = "Output of `cargo metadata` was not valid utf8"];
+        Json(::serde_json::Error) #[doc = "Deserialization error (structure of json did not match expected structure)"];
     }
 }


### PR DESCRIPTION
Uglier than before, but at least rustdoc picks up the comments now so we can remove the `allow`.