### PR TITLE
Make source field public

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -36,7 +36,8 @@ where
 pub struct Dependency {
     /// Name as given in the `Cargo.toml`
     pub name: String,
-    source: Option<String>,
+    /// The source of dependency
+    pub source: Option<String>,
     /// The required version
     pub req: VersionReq,
     /// The kind of dependency this is


### PR DESCRIPTION
I would like to make the source field public to see if the dependency is local or not.