### PR TITLE
Add support for package.metadata table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ version = "0.9"
 [dev-dependencies]
 clap = "2.26.0"
 docopt = "0.8.1"
+
+[package.metadata.cargo_metadata_test]
+some_field = true
+other_field = "foo"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,8 @@ pub struct Package {
     pub features: HashMap<String, Vec<String>>,
     /// Path containing the `Cargo.toml`
     pub manifest_path: String,
+    /// Contents of the free form package.metadata section
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
     #[doc(hidden)]
     #[serde(skip)]
     __do_not_match_exhaustively: (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub struct Package {
     /// Path containing the `Cargo.toml`
     pub manifest_path: String,
     /// Contents of the free form package.metadata section
+    #[serde(default)]
     pub metadata: serde_json::Value,
     #[doc(hidden)]
     #[serde(skip)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,30 @@ pub struct Package {
     /// Path containing the `Cargo.toml`
     pub manifest_path: String,
     /// Contents of the free form package.metadata section
+    ///
+    /// This contents can be serialized to a struct using serde:
+    ///
+    /// ```rust
+    /// #[macro_use]
+    /// extern crate serde_json;
+    /// #[macro_use]
+    /// extern crate serde_derive;
+    ///
+    /// #[derive(Debug, Deserialize)]
+    /// struct SomePackageMetadata {
+    ///     some_value: i32,
+    /// }
+    ///
+    /// fn main() {
+    ///     let value = json!({
+    ///         "some_value": 42,
+    ///     });
+    ///
+    ///     let package_metadata: SomePackageMetadata = serde_json::from_value(value).unwrap();
+    ///     assert_eq!(package_metadata.some_value, 42);
+    /// }
+    ///
+    /// ```
     #[serde(default)]
     pub metadata: serde_json::Value,
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ pub struct Package {
     /// Path containing the `Cargo.toml`
     pub manifest_path: String,
     /// Contents of the free form package.metadata section
-    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    pub metadata: serde_json::Value,
     #[doc(hidden)]
     #[serde(skip)]
     __do_not_match_exhaustively: (),

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -4,6 +4,7 @@ extern crate serde_json;
 
 use std::env::current_dir;
 use std::path::Path;
+use std::env;
 
 use semver::Version;
 
@@ -29,16 +30,19 @@ fn metadata() {
     assert_eq!(metadata.packages[0].targets[1].kind[0], "test");
     assert_eq!(metadata.packages[0].targets[1].crate_types[0], "bin");
 
-    let package_metadata = &metadata.packages[0].metadata.as_object()
-        .expect("package.metadata must be a table");
-    assert_eq!(package_metadata.len(), 1);
-    let test_package_metadata = match package_metadata.get("cargo_metadata_test").unwrap() {
-        serde_json::Value::Object(metadata) => metadata,
-        _ => panic!(),
-    };
-    assert_eq!(test_package_metadata.len(), 2);
-    assert_eq!(test_package_metadata.get("some_field"), Some(&serde_json::Value::Bool(true)));
-    assert_eq!(test_package_metadata.get("other_field"), Some(&serde_json::Value::String("foo".into())));
+    // Hack until the package metadata field reaches the stable channel (in version 1.27).
+    if env::var("TRAVIS_RUST_VERSION") != Ok("stable".into()) {
+        let package_metadata = &metadata.packages[0].metadata.as_object()
+            .expect("package.metadata must be a table");
+        assert_eq!(package_metadata.len(), 1);
+        let test_package_metadata = match package_metadata.get("cargo_metadata_test").unwrap() {
+            serde_json::Value::Object(metadata) => metadata,
+            _ => panic!(),
+        };
+        assert_eq!(test_package_metadata.len(), 2);
+        assert_eq!(test_package_metadata.get("some_field"), Some(&serde_json::Value::Bool(true)));
+        assert_eq!(test_package_metadata.get("other_field"), Some(&serde_json::Value::String("foo".into())));
+    }
 }
 
 #[test]

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -28,6 +28,16 @@ fn metadata() {
     assert_eq!(metadata.packages[0].targets[1].name, "selftest");
     assert_eq!(metadata.packages[0].targets[1].kind[0], "test");
     assert_eq!(metadata.packages[0].targets[1].crate_types[0], "bin");
+
+    let package_metadata = metadata.packages[0].metadata.as_ref().expect("metadata key missing");
+    assert_eq!(package_metadata.len(), 1);
+    let test_package_metadata = match package_metadata.get("cargo_metadata_test").unwrap() {
+        serde_json::Value::Object(metadata) => metadata,
+        _ => panic!(),
+    };
+    assert_eq!(test_package_metadata.len(), 2);
+    assert_eq!(test_package_metadata.get("some_field"), Some(&serde_json::Value::Bool(true)));
+    assert_eq!(test_package_metadata.get("other_field"), Some(&serde_json::Value::String("foo".into())));
 }
 
 #[test]

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -29,7 +29,8 @@ fn metadata() {
     assert_eq!(metadata.packages[0].targets[1].kind[0], "test");
     assert_eq!(metadata.packages[0].targets[1].crate_types[0], "bin");
 
-    let package_metadata = metadata.packages[0].metadata.as_ref().expect("metadata key missing");
+    let package_metadata = &metadata.packages[0].metadata.as_object()
+        .expect("package.metadata must be a table");
     assert_eq!(package_metadata.len(), 1);
     let test_package_metadata = match package_metadata.get("cargo_metadata_test").unwrap() {
         serde_json::Value::Object(metadata) => metadata,


### PR DESCRIPTION
Since https://github.com/rust-lang/cargo/pull/5360 `cargo metadata` outputs the contents of the [optional `package.metadata` table](https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table-optional). This PR adds support for the table to this crate. Since the table can contain arbitrary content, the return type is a dynamic `serde_json::Map`.

Unresolved questions:

- Is it ok to expose types of the serde_json dependency in the public API? Or do we need to make the `serde_json` dependency public?
- The test doesn't work on stable yet. Is there a way to conditionally execute the test only on nightly and beta?