### PR TITLE
Re-export backtrace feature of error-chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-error-chain = "0.11.0"
+error-chain = {version = "0.11.0", default-features = false}
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"
@@ -16,6 +16,10 @@ serde_json = "1.0.1"
 [dependencies.semver]
 features = ["serde"]
 version = "0.9"
+
+[features]
+default = ["backtrace"]
+backtrace = ["error-chain/backtrace"]
 
 [dev-dependencies]
 clap = "2.26.0"


### PR DESCRIPTION
On Linux and other targets, the `backtrace` crate relies upon the `cc` crate to compile `libbacktrace` – a C library. This can complicate the build.

This pull request re-exposes the `backtrace` feature of `error-chain` such that it can optionally be disabled.