### PR TITLE
Add building without backtrace feature to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ matrix:
 
 script:
   - cargo build --verbose
+  - cargo build --verbose --no-default-features
   - cargo test --verbose
+  - cargo test --verbose --no-default-features


### PR DESCRIPTION
In response to https://github.com/oli-obk/cargo_metadata/pull/38#issuecomment-401598850