### PR TITLE
Update error-chain to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-error-chain = {version = "0.11.0", default-features = false}
+error-chain = {version = "0.12.0", default-features = false}
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"


### PR DESCRIPTION
This removes a compiler warning which originates in a error-chain macro