### PR TITLE
Accept `AsRef<Path>` instead of just `Path`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ pub enum CargoOpt {
 /// # Parameters
 ///
 /// - `manifest_path`: Path to the manifest.
-pub fn metadata(manifest_path: Option<&Path>) -> Result<Metadata> {
+pub fn metadata<P: AsRef<Path>>(manifest_path: Option<P>) -> Result<Metadata> {
     metadata_run(manifest_path, false, None)
 }
 
@@ -274,7 +274,7 @@ pub fn metadata(manifest_path: Option<&Path>) -> Result<Metadata> {
 ///
 /// - `manifest_path`: Path to the manifest.
 /// - `deps`: Whether to include dependencies.
-pub fn metadata_deps(manifest_path: Option<&Path>, deps: bool) -> Result<Metadata> {
+pub fn metadata_deps<P: AsRef<Path>>(manifest_path: Option<P>, deps: bool) -> Result<Metadata> {
     metadata_run(manifest_path, deps, None)
 }
 
@@ -285,7 +285,8 @@ pub fn metadata_deps(manifest_path: Option<&Path>, deps: bool) -> Result<Metadat
 /// - `manifest_path`: Path to the manifest.
 /// - `deps`: Whether to include dependencies.
 /// - `feat`: Which features to include, `None` for defaults.
-pub fn metadata_run(manifest_path: Option<&Path>, deps: bool, features: Option<CargoOpt>) -> Result<Metadata> {
+pub fn metadata_run<P: AsRef<Path>>(manifest_path: Option<P>, deps: bool, features: Option<CargoOpt>) -> Result<Metadata> {
+    let manifest_path = manifest_path.as_ref().map(|p| p.as_ref());
     let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
     let mut cmd = Command::new(cargo);
     cmd.arg("metadata");

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -6,7 +6,7 @@ extern crate serde_json;
 extern crate serde_derive;
 
 use std::env::current_dir;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::env;
 
 use semver::Version;
@@ -21,7 +21,7 @@ struct TestPackageMetadata {
 
 #[test]
 fn metadata() {
-    let metadata = cargo_metadata::metadata(None).unwrap();
+    let metadata = cargo_metadata::metadata(None::<&Path>).unwrap();
 
     assert_eq!(
         current_dir().unwrap().join("target"),
@@ -54,6 +54,21 @@ fn metadata() {
             other_field: "foo".into(),
         });
     }
+}
+
+#[test]
+fn accepts_more_than_paths() {
+    let _ = cargo_metadata::metadata(Some("Cargo.toml")).unwrap();
+    let _ = cargo_metadata::metadata(Some(String::from("Cargo.toml"))).unwrap();
+    let _ = cargo_metadata::metadata(Some(PathBuf::from("Cargo.toml"))).unwrap();
+
+    let _ = cargo_metadata::metadata_deps(Some("Cargo.toml"), true).unwrap();
+    let _ = cargo_metadata::metadata_deps(Some(String::from("Cargo.toml")), true).unwrap();
+    let _ = cargo_metadata::metadata_deps(Some(PathBuf::from("Cargo.toml")), true).unwrap();
+
+    let _ = cargo_metadata::metadata_run(Some("Cargo.toml"), true, None).unwrap();
+    let _ = cargo_metadata::metadata_run(Some(String::from("Cargo.toml")), true, None).unwrap();
+    let _ = cargo_metadata::metadata_run(Some(PathBuf::from("Cargo.toml")), true, None).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This makes it more ergonomic for library users.