### PR TITLE
Bump serde dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [dependencies]
 error-chain = {version = "0.12.0", default-features = false}
-serde = "1.0.2"
+serde = "1.0.59"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"
 


### PR DESCRIPTION
This crate uses the `serde(transparent)` container attribute but this
attribute was only added in serde v1.0.59.