### PR TITLE
Bump serde_derive version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 [dependencies]
 error-chain = {version = "0.12.0", default-features = false}
 serde = "1.0.59"
-serde_derive = "1.0.2"
+serde_derive = "1.0.59"
 serde_json = "1.0.1"
 
 [dependencies.semver]


### PR DESCRIPTION
`#[serde(transparent)]` wasn't implemented in `serde_derive` until [v1.0.59](https://github.com/serde-rs/serde/releases/tag/v1.0.59), but it's used here:

https://github.com/oli-obk/cargo_metadata/blob/313cc0b85d4cb1b6ad6fc95004450f88740e02c9/src/lib.rs#L236

(This actually caused a build failure for me in an unrelated crate since I hadn't run `cargo update` in forever :man_shrugging:)