### PR TITLE
Fix error when no categories are provided

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,8 +176,10 @@ pub struct Package {
     /// Path containing the `Cargo.toml`
     pub manifest_path: String,
     /// Categories as given in the `Cargo.toml`
+    #[serde(default)]
     pub categories: Vec<String>,
     /// Keywords as given in the `Cargo.toml`
+    #[serde(default)]
     pub keywords: Vec<String>,
     /// Readme as given in the `Cargo.toml`
     pub readme: Option<String>,


### PR DESCRIPTION
The error seems to be extremely rare, for some reason.

Conditions:
- rustc 0.24.0 (Stable)
- Linux (travis build, so I don't know which one exactly)
- cargo_metadata version 0.6.2
- Project is nested:
-- Parent project isn't published
-- Child project is published
-- cargo_metadata called from tests in the parent project
-- Parent project isn't a workspace
-- Parent project `Cargo.toml` is minimal; no `categories` entry.
- (Specific build log: https://travis-ci.org/budziq/rust-skeptic/jobs/462642234 from budziq/rust-skeptic#91)