### PR TITLE
Update dep, silence deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ backtrace = ["error-chain/backtrace"]
 
 [dev-dependencies]
 clap = "2.26.0"
-docopt = "0.8.1"
+docopt = "1.0.2"
 
 [package.metadata.cargo_metadata_test]
 some_field = true

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // .cause has been changed to .source
+
 //! Create the `Error`, `ErrorKind`, `ResultExt`, and `Result` types
 
 error_chain!{


### PR DESCRIPTION
error-chain uses deprecated method and there's no update yet.
docopt is now stable.