### PR TITLE
Replace trim_left_matches with trim_start_matches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - rust: "nightly"
     - rust: "beta"
     - rust: "stable"
-    - rust: "1.27.0"
+    - rust: "1.30.0"
 
 script:
   - cargo build --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!         cmd.manifest_path(args.next().unwrap());
 //!     }
 //!     Some(p) => {
-//!         cmd.manifest_path(p.trim_left_matches("--manifest-path="));
+//!         cmd.manifest_path(p.trim_start_matches("--manifest-path="));
 //!     }
 //!     None => {}
 //! };


### PR DESCRIPTION
Now that 1.33.0 is out and `trim_left_matches()` deprecation has reached stable channel it may be a good time to update the example/doc test

Fix #65 