### PR TITLE
Fix support for current_dir.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,6 +486,10 @@ impl MetadataCommand {
             cmd.arg("--no-deps");
         }
 
+        if let Some(path) = self.current_dir.as_ref() {
+            cmd.current_dir(path);
+        }
+
         if let Some(features) = &self.features {
             match features {
                 CargoOpt::AllFeatures => cmd.arg("--all-features"),

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -474,3 +474,14 @@ fn links() {
     let meta: Metadata = serde_json::from_str(json).unwrap();
     assert_eq!(meta.packages[0].links, Some("somelib".to_string()));
 }
+
+
+#[test]
+fn current_dir() {
+    let meta = MetadataCommand::new()
+        .current_dir("tests/all/namedep")
+        .exec()
+        .unwrap();
+    let namedep = meta.packages.iter().find(|p| p.name == "namedep").unwrap();
+    assert!(namedep.name.starts_with("namedep"));
+}


### PR DESCRIPTION
Change MetadataCommand::current_dir so it has an effect.

Fixes #82. This is a work around for the issue #82.