### PR TITLE
replace failure with just manually implementing an error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-failure = "0.1.5"
 serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,6 @@
 //! let output = command.wait().expect("Couldn't get cargo's exit status");
 //! ```
 
-#[macro_use]
-extern crate failure;
 extern crate semver;
 extern crate serde;
 #[macro_use]


### PR DESCRIPTION
We don't actually use any of failure's features anyway, and having less public dependencies is good for a library.

Here's what we lose from this:

```
λ cargo update
    Updating crates.io index
    Removing backtrace v0.3.33
    Removing backtrace-sys v0.1.31
    Removing cc v1.0.38
    Removing cfg-if v0.1.9
    Removing failure v0.1.5
    Removing failure_derive v0.1.5
    Removing rustc-demangle v0.1.15
    Removing synstructure v0.10.2
```

Note that technically this is a breaking change