### PR TITLE
package.readme should be Option<PathBuf> rather than Option<String>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ pub struct Package {
     #[serde(default)]
     pub keywords: Vec<String>,
     /// Readme as given in the `Cargo.toml`
-    pub readme: Option<String>,
+    pub readme: Option<PathBuf>,
     /// Repository as given in the `Cargo.toml`
     pub repository: Option<String>,
     /// Default Rust edition for the package

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,22 @@ pub struct Package {
     __do_not_match_exhaustively: (),
 }
 
+impl Package {
+    /// Full path to the license file if one is present in the manifest
+    pub fn license_file(&self) -> Option<PathBuf> {
+        self.license_file
+            .as_ref()
+            .map(|file| self.manifest_path.join(file))
+    }
+
+    /// Full path to the readme file if one is present in the manifest
+    pub fn readme(&self) -> Option<PathBuf> {
+        self.readme
+            .as_ref()
+            .map(|file| self.manifest_path.join(file))
+    }
+}
+
 /// The source of a package such as crates.io.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(transparent)]

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -281,7 +281,7 @@ fn all_the_fields() {
     assert!(all.manifest_path.ends_with("all/Cargo.toml"));
     assert_eq!(all.categories, vec!["command-line-utilities"]);
     assert_eq!(all.keywords, vec!["cli"]);
-    assert_eq!(all.readme, Some("README.md".to_string()));
+    assert_eq!(all.readme, Some(PathBuf::from("README.md")));
     assert_eq!(
         all.repository,
         Some("https://github.com/oli-obk/cargo_metadata/".to_string())


### PR DESCRIPTION
Since the `Package::readme` field is public this would be a breaking change.
However, the ~aaec6f1~ 5448745  by itself should not break anything, while providing handy accessors, even without the updating (~3706bb2~ 66c3296) `Package::readme` field.