### PR TITLE
make diagnostic types pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub use messages::{
 };
 
 mod dependency;
-mod diagnostic;
+pub mod diagnostic;
 mod errors;
 mod messages;
 


### PR DESCRIPTION
To be able to fully use `parse_messages`, pub access is required for diagnostic types. Currently, it's not possible to match on `Diagnostic`'s `level` field because `DiagnosticLevel` is private.