### PR TITLE
Make Source's and Platform's inner String pub

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -74,7 +74,7 @@ pub struct Dependency {
 /// A target platform.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub struct Platform(String);
+pub struct Platform(pub String);
 
 impl fmt::Display for Platform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -74,10 +74,13 @@ pub struct Dependency {
 /// A target platform.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub struct Platform(pub String);
+pub struct Platform {
+    /// The underlying string representation of a platform.
+    pub repr: String,
+}
 
 impl fmt::Display for Platform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
+        fmt::Display::fmt(&self.repr, f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@
 //! # #[macro_use] extern crate serde_derive;
 //! # use std::path::Path;
 //! # use docopt::Docopt;
-//! # fn main() {
 //! const USAGE: &str = "
 //!     Cargo metadata test function
 //!
@@ -60,7 +59,6 @@
 //!     cmd.manifest_path(path);
 //! }
 //! let _metadata = cmd.exec().unwrap();
-//! # }
 //! ```
 //!
 //! With [`clap`](https://docs.rs/clap):
@@ -92,7 +90,6 @@
 //! # #[macro_use] extern crate structopt;
 //! # use std::path::PathBuf;
 //! # use structopt::StructOpt;
-//! # fn main() {
 //! #[derive(Debug, StructOpt)]
 //! struct Opt {
 //!     #[structopt(name = "PATH", long="manifest-path", parse(from_os_str))]
@@ -105,7 +102,6 @@
 //!     cmd.manifest_path(path);
 //! }
 //! let _metadata = cmd.exec().unwrap();
-//! # }
 //! ```
 //!
 //! Pass features flags
@@ -114,7 +110,6 @@
 //! # // This should be kept in sync with the equivalent example in the readme.
 //! # extern crate cargo_metadata;
 //! # use std::path::Path;
-//! # fn main() {
 //! use cargo_metadata::{MetadataCommand, CargoOpt};
 //!
 //! let _metadata = MetadataCommand::new()
@@ -122,7 +117,6 @@
 //!     .features(CargoOpt::AllFeatures)
 //!     .exec()
 //!     .unwrap();
-//! # }
 //! ```
 //!
 //! Parse message-format output:
@@ -536,7 +530,7 @@ impl MetadataCommand {
         let cargo = self
             .cargo_path
             .clone()
-            .or_else(|| env::var("CARGO").map(|s| PathBuf::from(s)).ok())
+            .or_else(|| env::var("CARGO").map(PathBuf::from).ok())
             .unwrap_or_else(|| PathBuf::from("cargo"));
         let mut cmd = Command::new(cargo);
         cmd.args(&["metadata", "--format-version", "1"]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //! # #[macro_use] extern crate serde_derive;
 //! # use std::path::Path;
 //! # use docopt::Docopt;
+//! # fn main() {
 //! const USAGE: &str = "
 //!     Cargo metadata test function
 //!
@@ -59,6 +60,7 @@
 //!     cmd.manifest_path(path);
 //! }
 //! let _metadata = cmd.exec().unwrap();
+//! # }
 //! ```
 //!
 //! With [`clap`](https://docs.rs/clap):
@@ -90,6 +92,7 @@
 //! # #[macro_use] extern crate structopt;
 //! # use std::path::PathBuf;
 //! # use structopt::StructOpt;
+//! # fn main() {
 //! #[derive(Debug, StructOpt)]
 //! struct Opt {
 //!     #[structopt(name = "PATH", long="manifest-path", parse(from_os_str))]
@@ -102,6 +105,7 @@
 //!     cmd.manifest_path(path);
 //! }
 //! let _metadata = cmd.exec().unwrap();
+//! # }
 //! ```
 //!
 //! Pass features flags
@@ -110,6 +114,7 @@
 //! # // This should be kept in sync with the equivalent example in the readme.
 //! # extern crate cargo_metadata;
 //! # use std::path::Path;
+//! # fn main() {
 //! use cargo_metadata::{MetadataCommand, CargoOpt};
 //!
 //! let _metadata = MetadataCommand::new()
@@ -117,6 +122,7 @@
 //!     .features(CargoOpt::AllFeatures)
 //!     .exec()
 //!     .unwrap();
+//! # }
 //! ```
 //!
 //! Parse message-format output:
@@ -533,7 +539,7 @@ impl MetadataCommand {
         let cargo = self
             .cargo_path
             .clone()
-            .or_else(|| env::var("CARGO").map(PathBuf::from).ok())
+            .or_else(|| env::var("CARGO").map(|s| PathBuf::from(s)).ok())
             .unwrap_or_else(|| PathBuf::from("cargo"));
         let mut cmd = Command::new(cargo);
         cmd.args(&["metadata", "--format-version", "1"]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl Package {
 /// The source of a package such as crates.io.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub struct Source(String);
+pub struct Source(pub String);
 
 impl Source {
     /// Returns true if the source is crates.io.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,18 +408,21 @@ impl Package {
 /// The source of a package such as crates.io.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub struct Source(pub String);
+pub struct Source {
+    /// The underlying string representation of a source.
+    pub repr: String,
+}
 
 impl Source {
     /// Returns true if the source is crates.io.
     pub fn is_crates_io(&self) -> bool {
-        self.0 == "registry+https://github.com/rust-lang/crates.io-index"
+        self.repr == "registry+https://github.com/rust-lang/crates.io-index"
     }
 }
 
 impl std::fmt::Display for Source {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
+        fmt::Display::fmt(&self.repr, f)
     }
 }
 


### PR DESCRIPTION
AFAICT `Source` and `Platform` are the only 2 public types that don't publicly expose their inner representation, which makes them inconsistent with the rest of the types exposed by cargo_metadata. This change makes them both use the same pattern as `PackageId` so that they can be inspected without doing a copy via Display first, but allows the type to evolve in the future with a more type safe interface (such as #94) in the future without necessarily breaking backwards compatibility.

Resolves: #95 