### PR TITLE
Typo fixed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ pub struct Target {
     pub name: String,
     /// Kind of target ("bin", "example", "test", "bench", "lib")
     pub kind: Vec<String>,
-    /// Almost the same as `kind`, except when an example is a library instad of an executable.
+    /// Almost the same as `kind`, except when an example is a library instead of an executable.
     /// In that case `crate_types` contains things like `rlib` and `dylib` while `kind` is `example`
     #[serde(default)]
     pub crate_types: Vec<String>,


### PR DESCRIPTION
Thanks a lot for this crate! Here is a typo that I spotted while reading the documentation. [codepsell](https://github.com/codespell-project/codespell) did not find more typos.
