### PR TITLE
src/errors: fix compiler warning

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,7 +93,7 @@ impl fmt::Display for Error {
 }
 
 impl ::std::error::Error for Error {
-    fn source(&self) -> Option<&(::std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::CargoMetadata { .. } => None,
             Error::Io(err) => Some(err),


### PR DESCRIPTION
Fix the following warning:

warning: trait objects without an explicit `dyn` are deprecated
  --> src/errors.rs:96:34
   |
96 |     fn source(&self) -> Option<&(::std::error::Error + 'static)> {
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn ::std::error::Error + 'static`
   |
   = note: `#[warn(bare_trait_objects)]` on by default