### PR TITLE
src/lib: fix license_file()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl Package {
     pub fn license_file(&self) -> Option<PathBuf> {
         self.license_file
             .as_ref()
-            .map(|file| self.manifest_path.join(file))
+            .map(|file| self.manifest_path.parent().unwrap_or(&self.manifest_path).join(file))
     }
 
     /// Full path to the readme file if one is present in the manifest

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -178,6 +178,7 @@ fn all_the_fields() {
     assert_eq!(all.description, Some("Package description.".to_string()));
     assert_eq!(all.license, Some("MIT/Apache-2.0".to_string()));
     assert_eq!(all.license_file, Some(PathBuf::from("LICENSE")));
+    assert!(all.license_file().unwrap().ends_with("tests/all/LICENSE"));
     assert_eq!(all.publish, Some(vec![]));
     assert_eq!(all.links, Some("foo".to_string()));
 


### PR DESCRIPTION
According to the documentation Package.license_file() returns the full path
to the license file, if present in metadata. However, in reality it
returned the name of the license file concatenated to the full path of the
Cargo.toml file.