### PR TITLE
Out of tree

### DIFF
--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -20,10 +20,13 @@ struct TestPackageMetadata {
 
 #[test]
 fn metadata() {
-    let metadata = MetadataCommand::new().no_deps().exec().unwrap();
+    let manifest_dir = current_dir().unwrap();
+    let manifest_path = "Cargo.toml";
+    let metadata = MetadataCommand::new().no_deps()
+        .manifest_path(&manifest_path).exec().unwrap();
 
     assert_eq!(
-        current_dir().unwrap().join("target"),
+        manifest_dir.join("target"),
         Path::new(&metadata.target_directory)
     );
 
@@ -63,31 +66,33 @@ fn metadata() {
 
 #[test]
 fn builder_interface() {
+    let manifest_dir = current_dir().unwrap();
+    let manifest_path = "Cargo.toml";
     let _ = MetadataCommand::new()
-        .manifest_path("Cargo.toml")
+        .manifest_path(manifest_path)
         .exec()
         .unwrap();
     let _ = MetadataCommand::new()
-        .manifest_path(String::from("Cargo.toml"))
+        .manifest_path(String::from(manifest_path))
         .exec()
         .unwrap();
     let _ = MetadataCommand::new()
-        .manifest_path(PathBuf::from("Cargo.toml"))
+        .manifest_path(PathBuf::from(manifest_path))
         .exec()
         .unwrap();
     let _ = MetadataCommand::new()
-        .manifest_path("Cargo.toml")
+        .manifest_path(manifest_path)
         .no_deps()
         .exec()
         .unwrap();
     let _ = MetadataCommand::new()
-        .manifest_path("Cargo.toml")
+        .manifest_path(manifest_path)
         .features(CargoOpt::AllFeatures)
         .exec()
         .unwrap();
     let _ = MetadataCommand::new()
-        .manifest_path("Cargo.toml")
-        .current_dir(current_dir().unwrap())
+        .manifest_path(manifest_path)
+        .current_dir(manifest_dir)
         .exec()
         .unwrap();
 }
@@ -131,8 +136,9 @@ fn cargo_path() {
 #[test]
 fn metadata_deps() {
     std::env::set_var("CARGO_PROFILE", "3");
+    let manifest_path = "Cargo.toml";
     let metadata = MetadataCommand::new()
-        .manifest_path("Cargo.toml")
+        .manifest_path(&manifest_path)
         .exec()
         .unwrap();
     let this_id = metadata


### PR DESCRIPTION
Hi. I like to do builds out of tree, with the actual source code not writeable by the build process. This is achieved with cargo --manifest-path=..../Cargo.toml --target-dir=target.  This does not work right now if one of the parents of the source code directory has its own cargo config: the cargo run by the cargo_metadata tests picks up the wrong cargo config.

In this MR I propose to fix this by changing directory to $CARGO_HOME.  This is not ideal: it would be better to change back to the invocation directory, but the invocation directory is not currently available (https://github.com/rust-lang/cargo/issues/8148)

I have checked that "cargo test" still works in both in-tree and out-of-tree builds.