### PR TITLE
Split command parse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,6 +488,13 @@ impl MetadataCommand {
         Ok(cmd)
     }
 
+    /// Parses `cargo metadata` output.  `data` must have been
+    /// produced by a command built with `cargo_command`.
+    pub fn parse<T : AsRef<str>>(data : T) -> Result<Metadata> {
+        let meta = serde_json::from_str(data.as_ref())?;
+        Ok(meta)
+    }
+
     /// Runs configured `cargo metadata` and returns parsed `Metadata`.
     pub fn exec(&mut self) -> Result<Metadata> {
         let mut cmd = self.cargo_command()?;
@@ -501,7 +508,6 @@ impl MetadataCommand {
             .lines()
             .find(|line| line.starts_with('{'))
             .ok_or_else(|| Error::NoJson)?;
-        let meta = serde_json::from_str(stdout)?;
-        Ok(meta)
+        Self::parse(stdout)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,8 +452,10 @@ impl MetadataCommand {
         self.other_options = options.as_ref().to_vec();
         self
     }
-    /// Runs configured `cargo metadata` and returns parsed `Metadata`.
-    pub fn exec(&mut self) -> Result<Metadata> {
+
+    /// Builds a command for `cargo metadata`.  This is the first
+    /// part of the work of `exec`.
+    pub fn cargo_command(&self) -> Result<Command> {
         let cargo = self
             .cargo_path
             .clone()
@@ -482,6 +484,13 @@ impl MetadataCommand {
             cmd.arg("--manifest-path").arg(manifest_path.as_os_str());
         }
         cmd.args(&self.other_options);
+
+        Ok(cmd)
+    }
+
+    /// Runs configured `cargo metadata` and returns parsed `Metadata`.
+    pub fn exec(&mut self) -> Result<Metadata> {
+        let mut cmd = self.cargo_command()?;
         let output = cmd.output()?;
         if !output.status.success() {
             return Err(Error::CargoMetadata {


### PR DESCRIPTION
Hi.

I have an application where I wanted to save the output from cargo metadata, which cargo_metadata produces internally.

The Metadata struct contains two useful pieces of functionality: the Command builder and the parser (which is built with serde of course).  I think the best approach is simply to expose these two pieces so they can be used separately.  The split is still not complete because `--format-version` would need special handling, but it's good enough for my purposes.

I have tested this with `cargo check` (my tests were run with this rebased on top of my out-of-tree tests chdir MR branch).  There are no separate new tests because both the new functions `cargo_command` and `parse` are called by `exec`, so already tested.  `parse` is trivial in any case and provided partly in order to document what is going on.

Although a FromStr impl would have been possible, I thought that probably wasn't desirable.

Regards,
Ian.