### PR TITLE
 Correct BuildScript.cfgs to be String rather than PathBuf

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -72,7 +72,7 @@ pub struct BuildScript {
     /// The paths to search when resolving libs
     pub linked_paths: Vec<PathBuf>,
     /// Various `--cfg` flags to pass to the compiler
-    pub cfgs: Vec<PathBuf>,
+    pub cfgs: Vec<String>,
     /// The environment variables to add to the compilation
     pub env: Vec<(String, String)>,
     /// The `OUT_DIR` environment variable where this script places its output


### PR DESCRIPTION
As per the the cargo documentation which [says](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cfg):

> single identifier, or any arbitrary key/value pair [...] key should be a Rust identifier, the value should be a string

`String` should cover this.

This is a breaking change.

ref rust-analyzer/rust-analyzer#4296