### PR TITLE
deps: bump semver from 0.9 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0.1"
 
 [dependencies.semver]
 features = ["serde"]
-version = "0.9"
+version = "0.10"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,7 @@ impl MetadataCommand {
         let cargo = self
             .cargo_path
             .clone()
-            .or_else(|| env::var("CARGO").map(|s| PathBuf::from(s)).ok())
+            .or_else(|| env::var("CARGO").map(PathBuf::from).ok())
             .unwrap_or_else(|| PathBuf::from("cargo"));
         let mut cmd = Command::new(cargo);
         cmd.args(&["metadata", "--format-version", "1"]);


### PR DESCRIPTION
This will allow us to bump semver in clippy, it currently conflicts because cargo-metadata still requires 0.9 instead of 0.10.