### PR TITLE
Advanced feature configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,7 +415,7 @@ pub struct MetadataCommand {
     manifest_path: Option<PathBuf>,
     current_dir: Option<PathBuf>,
     no_deps: bool,
-    features: Option<CargoOpt>,
+    features: Vec<CargoOpt>,
     other_options: Vec<String>,
 }
 
@@ -448,8 +448,20 @@ impl MetadataCommand {
         self
     }
     /// Which features to include.
+    ///
+    /// Call this multiple times to specify advanced feature configurations:
+    ///
+    /// ```no_run
+    /// # use cargo_metadata::{CargoOpt, MetadataCommand};
+    /// MetadataCommand::new()
+    ///     .features(CargoOpt::NoDefaultFeatures)
+    ///     .features(CargoOpt::SomeFeatures(vec!["feat1".into(), "feat2".into()]))
+    ///     .features(CargoOpt::SomeFeatures(vec!["feat3".into()]))
+    ///     // ...
+    ///     # ;
+    /// ```
     pub fn features(&mut self, features: CargoOpt) -> &mut MetadataCommand {
-        self.features = Some(features);
+        self.features.push(features);
         self
     }
     /// Arbitrary command line flags to pass to `cargo`.  These will be added
@@ -478,8 +490,8 @@ impl MetadataCommand {
             cmd.current_dir(path);
         }
 
-        if let Some(features) = &self.features {
-            match features {
+        for feature in &self.features {
+            match feature {
                 CargoOpt::AllFeatures => cmd.arg("--all-features"),
                 CargoOpt::NoDefaultFeatures => cmd.arg("--no-default-features"),
                 CargoOpt::SomeFeatures(ftrs) => cmd.arg("--features").arg(ftrs.join(",")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,13 +466,47 @@ impl MetadataCommand {
     ///     # ;
     /// ```
     ///
-    /// Unlike `cargo metadata`, which disallows multiple `--all-features` or `--no-default-features`
-    /// options, it's OK to specify those options multiple times using `features()`.
+    /// # Panics
+    ///
+    /// `cargo metadata` rejects multiple `--no-default-features` flags. Similarly, the `features()`
+    /// method panics when specifiying multiple `CargoOpt::NoDefaultFeatures`:
+    ///
+    /// ```should_panic
+    /// # use cargo_metadata::{CargoOpt, MetadataCommand};
+    /// MetadataCommand::new()
+    ///     .features(CargoOpt::NoDefaultFeatures)
+    ///     .features(CargoOpt::NoDefaultFeatures) // <-- panic!
+    ///     // ...
+    ///     # ;
+    /// ```
+    ///
+    /// The method also panics for multiple `CargoOpt::AllFeatures` arguments:
+    ///
+    /// ```should_panic
+    /// # use cargo_metadata::{CargoOpt, MetadataCommand};
+    /// MetadataCommand::new()
+    ///     .features(CargoOpt::AllFeatures)
+    ///     .features(CargoOpt::AllFeatures) // <-- panic!
+    ///     // ...
+    ///     # ;
+    /// ```
     pub fn features(&mut self, features: CargoOpt) -> &mut MetadataCommand {
         match features {
             CargoOpt::SomeFeatures(features) => self.features.extend(features),
-            CargoOpt::NoDefaultFeatures => self.no_default_features = true,
-            CargoOpt::AllFeatures => self.all_features = true,
+            CargoOpt::NoDefaultFeatures => {
+                assert!(
+                    !self.no_default_features,
+                    "Do not supply CargoOpt::NoDefaultFeatures more than once!"
+                );
+                self.no_default_features = true;
+            }
+            CargoOpt::AllFeatures => {
+                assert!(
+                    !self.all_features,
+                    "Do not supply CargoOpt::AllFeatures more than once!"
+                );
+                self.all_features = true;
+            }
         }
         self
     }

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -555,4 +555,22 @@ fn advanced_feature_configuration() {
         sorted!(all_features),
         vec!["bitflags", "default", "feat1", "feat2"]
     );
+
+    // `cargo metadata` disallows multiple `--all-features` flags. But, we'll allow
+    // it. Might be convenient for users.
+    let more_all_features = build_features(|meta| {
+        meta.features(CargoOpt::AllFeatures)
+            .features(CargoOpt::AllFeatures)
+    });
+    assert_eq!(
+        sorted!(more_all_features),
+        vec!["bitflags", "default", "feat1", "feat2"]
+    );
+
+    // Same goes for multiple `--no-default-features` flags...
+    let more_no_default_features = build_features(|meta| {
+        meta.features(CargoOpt::NoDefaultFeatures)
+            .features(CargoOpt::NoDefaultFeatures)
+    });
+    assert!(more_no_default_features.is_empty());
 }

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -573,4 +573,15 @@ fn advanced_feature_configuration() {
             .features(CargoOpt::NoDefaultFeatures)
     });
     assert!(more_no_default_features.is_empty());
+
+    // The '--all-features' flag supersedes other feature flags
+    let all_flag_variants = build_features(|meta| {
+        meta.features(CargoOpt::SomeFeatures(vec!["feat2".into()]))
+            .features(CargoOpt::NoDefaultFeatures)
+            .features(CargoOpt::AllFeatures)
+    });
+    assert_eq!(
+        sorted!(all_flag_variants),
+        sorted!(all_features)
+    );
 }

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -556,24 +556,6 @@ fn advanced_feature_configuration() {
         vec!["bitflags", "default", "feat1", "feat2"]
     );
 
-    // `cargo metadata` disallows multiple `--all-features` flags. But, we'll allow
-    // it. Might be convenient for users.
-    let more_all_features = build_features(|meta| {
-        meta.features(CargoOpt::AllFeatures)
-            .features(CargoOpt::AllFeatures)
-    });
-    assert_eq!(
-        sorted!(more_all_features),
-        vec!["bitflags", "default", "feat1", "feat2"]
-    );
-
-    // Same goes for multiple `--no-default-features` flags...
-    let more_no_default_features = build_features(|meta| {
-        meta.features(CargoOpt::NoDefaultFeatures)
-            .features(CargoOpt::NoDefaultFeatures)
-    });
-    assert!(more_no_default_features.is_empty());
-
     // The '--all-features' flag supersedes other feature flags
     let all_flag_variants = build_features(|meta| {
         meta.features(CargoOpt::SomeFeatures(vec!["feat2".into()]))


### PR DESCRIPTION
The PR addresses #79 while remaining API compatible. `MetadataCommand` now supports multiple calls to `features()`. We can now express

```bash
cargo metadata --no-default-features --features feat1
```

 as

```rust
MetadataCommand::new()
    .features(CargoOpt::NoDefaultFeatures)
    .features(CargoOpt::SomeFeatures(vec!["feat1".into()])
    // ...
```

See the tests for a demonstration.

Note that this is API compatible, but not behaviorally the same. This might break any user who relies on subsequent calls to `features()` that override previous calls to `features()`.