### PR TITLE
bump serde dependency to 1.0.107

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.79", features = ["derive"] }
+serde = { version = "1.0.107", features = ["derive"] }
 serde_json = "1.0.1"
 
 [dependencies.semver]


### PR DESCRIPTION
as older versions can't compile cargo_metadata because of https://github.com/serde-rs/serde/issues/1804