### PR TITLE
Pin a version of semver-parser to keep compatibility with 1.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 
 [dependencies]
 semver = { version = "0.11.0", features = ["serde"] }
+# Used to pin a version, so that semver-parser will compile on 1.32
+# Remove this when the MSRV is bumped or `semver` is updated.
+semver-parser = "=0.10.0"
 serde = { version = "1.0.107", features = ["derive"] }
 serde_json = { version = "1.0.59", features = ["unbounded_depth"] }
 


### PR DESCRIPTION
This fixes the following build error:

```
error[E0658]: non-builtin inner attributes are unstable (see issue #54726)
 --> /home/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/semver-parser-0.10.1/src/generated.rs:4:1
  |
4 | #![rustfmt::skip]
  | ^^^^^^^^^^^^^^^^^
```