### PR TITLE
Update documentation

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -57,7 +57,7 @@ pub struct Dependency {
     ///
     /// Use the [`Display`] trait to access the contents.
     ///
-    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+    /// [`Display`]: std::fmt::Display
     pub target: Option<Platform>,
     /// If the dependency is renamed, this is the new name for the dependency
     /// as a string.  None if it is not renamed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ pub struct DepKindInfo {
     /// graph. Use Cargo's `--filter-platform` flag if you only want to
     /// include dependencies for a specific platform.
     ///
-    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+    /// [`Display`]: std::fmt::Display
     pub target: Option<dependency::Platform>,
     #[doc(hidden)]
     #[serde(skip)]
@@ -247,7 +247,10 @@ pub struct DepKindInfo {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-/// A crate
+/// One or more crates described by a single `Cargo.toml`
+///
+/// Each [`target`][Package::targets] of a `Package` will be built as a crate.
+/// For more information, see <https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html>.
 pub struct Package {
     /// Name as given in the `Cargo.toml`
     pub name: String,
@@ -290,7 +293,7 @@ pub struct Package {
     /// Default Rust edition for the package
     ///
     /// Beware that individual targets may specify their own edition in
-    /// [`Target::edition`](struct.Target.html#structfield.edition).
+    /// [`Target::edition`].
     #[serde(default = "edition_default")]
     pub edition: String,
     /// Contents of the free form package.metadata section


### PR DESCRIPTION
- Note that a package is not the same as a crate, which closes https://github.com/oli-obk/cargo_metadata/issues/125
- Switch to intra-doc links now that they're stable