### PR TITLE
Use `cargo_platform` instead of an opaque string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
+cargo-platform = "0.1"
 semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0.107", features = ["derive"] }
 serde_json = { version = "1.0.59", features = ["unbounded_depth"] }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -2,7 +2,6 @@
 
 use semver::VersionReq;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::fmt;
 
 #[derive(PartialEq, Clone, Debug, Copy, Serialize, Deserialize)]
 /// Dependencies can come in three kinds
@@ -71,16 +70,4 @@ pub struct Dependency {
     __do_not_match_exhaustively: (),
 }
 
-/// A target platform.
-#[derive(Clone, Serialize, Deserialize, Debug)]
-#[serde(transparent)]
-pub struct Platform {
-    /// The underlying string representation of a platform.
-    pub repr: String,
-}
-
-impl fmt::Display for Platform {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.repr, f)
-    }
-}
+pub use cargo_platform::Platform;


### PR DESCRIPTION
Closes https://github.com/oli-obk/cargo_metadata/issues/94.

I'm not sure how to test this - maybe since it's in a different crate it doesn't need tests? The existing tests at least make sure that it parses successfully, though.