### PR TITLE
Don't return a Result from `cargo_command`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,7 +539,7 @@ impl MetadataCommand {
 
     /// Builds a command for `cargo metadata`.  This is the first
     /// part of the work of `exec`.
-    pub fn cargo_command(&self) -> Result<Command> {
+    pub fn cargo_command(&self) -> Command {
         let cargo = self
             .cargo_path
             .clone()
@@ -571,7 +571,7 @@ impl MetadataCommand {
         }
         cmd.args(&self.other_options);
 
-        Ok(cmd)
+        cmd
     }
 
     /// Parses `cargo metadata` output.  `data` must have been
@@ -583,8 +583,7 @@ impl MetadataCommand {
 
     /// Runs configured `cargo metadata` and returns parsed `Metadata`.
     pub fn exec(&self) -> Result<Metadata> {
-        let mut cmd = self.cargo_command()?;
-        let output = cmd.output()?;
+        let output = self.cargo_command().output()?;
         if !output.status.success() {
             return Err(Error::CargoMetadata {
                 stderr: String::from_utf8(output.stderr)?,


### PR DESCRIPTION
It can't ever fail.

Found while working on https://github.com/oli-obk/cargo_metadata/issues/81, I hope to have a fix for that soon.