### PR TITLE
Give a better message on IO errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,9 +76,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::CargoMetadata { stderr } => {
-                write!(f, "failed to run `cargo metadata`: {}", stderr.trim_end())
+                write!(f, "`cargo metadata` exited with an error: {}", stderr.trim_end())
             }
-            Error::Io(err) => write!(f, "{}", err),
+            Error::Io(err) => write!(f, "failed to start `cargo metadata`: {}", err),
             Error::Utf8(err) => write!(f, "cannot convert the stdout of `cargo metadata`: {}", err),
             Error::ErrUtf8(err) => {
                 write!(f, "cannot convert the stderr of `cargo metadata`: {}", err)


### PR DESCRIPTION
Before: `error: No such file or directory (os error 2)`
After: ``error: failed to start `cargo metadata`: No such file or directory (os error 2)``

Closes https://github.com/oli-obk/cargo_metadata/issues/81 (it's not a custom error but it should be much more clear what's going on).

I'm not sure the difference between 'failed to create the process' and 'the process ran but exited with an error' is very clear. I don't know how to improve it, though.