### PR TITLE
Recommend --message-format=json-rendered-diagnostics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! use cargo_metadata::Message;
 //!
 //! let mut command = Command::new("cargo")
-//!     .args(&["build", "--message-format=json"])
+//!     .args(&["build", "--message-format=json-render-diagnostics"])
 //!     .stdout(Stdio::piped())
 //!     .spawn()
 //!     .unwrap();


### PR DESCRIPTION
Otherwise, errors and warnings will be completely hidden.

This would have avoided https://github.com/deadlinks/cargo-deadlinks/issues/113.