### PR TITLE
NOISSUE - Derive `Eq` and `Hash` traits for `DependencyKind`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-target
 Cargo.lock
+.idea/
+target

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -4,7 +4,7 @@ use semver::VersionReq;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
-#[derive(PartialEq, Clone, Debug, Copy, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Clone, Debug, Copy, Hash, Serialize, Deserialize)]
 /// Dependencies can come in three kinds
 pub enum DependencyKind {
     #[serde(rename = "normal")]


### PR DESCRIPTION
We ran into this in `cargo-geiger` when migrating from `cargo::core` to `cargo_metadata`, where we used the DependencyKind enum as keys in a `HashMap`.
We have implemented a temporary work around, using a privately declared enum, but it would be great to be able to use this enum.
Thanks,
Josh