### PR TITLE
Added support for the diagnistic level failure-note

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -119,6 +119,9 @@ pub enum DiagnosticLevel {
     Error,
     /// Warning
     Warning,
+    /// Failure note
+    #[serde(rename = "failure-note")]
+    FailureNote,
     /// Note
     Note,
     /// Help


### PR DESCRIPTION
I don't know how this should be added correctly, so I just did it a way that works for me. It was also unclear how to add tests for it.

To generate a message with this level, an empty project with main.rs like this will do

    fn test(a: i32) {
        println!("Got {}", a);
    }
    
    fn main() {
        test("hello");
    }

The message in question is

    For more information about this error, try `rustc --explain E0308`.

The json output is

    {"reason":"compiler-message","package_id":"repro 0.1.0 (path+file:///home/boh/repro)","target":{"kind":["bin"],"crate_types":["bin"],"name":"repro","src_path":"/home/boh/repro/src/main.rs","edition":"2018","doc":true,"doctest":false,"test":true},"message":{"rendered":"For more information about this error, try `rustc --explain E0308`.\n","children":[],"code":null,"level":"failure-note","message":"For more information about this error, try `rustc --explain E0308`.","spans":[]}}