### PR TITLE
impl Display for DependencyKind

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,5 +1,7 @@
 //! This module contains `Dependency` and the types/functions it uses for deserialization.
 
+use std::fmt;
+
 use camino::Utf8PathBuf;
 use semver::VersionReq;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -26,6 +28,14 @@ pub enum DependencyKind {
 impl Default for DependencyKind {
     fn default() -> DependencyKind {
         DependencyKind::Normal
+    }
+}
+
+impl fmt::Display for DependencyKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = serde_json::to_string(self).unwrap();
+        // skip opening and closing quotes
+        f.write_str(&s[1..s.len() - 1])
     }
 }
 

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -597,3 +597,11 @@ fn advanced_feature_configuration() {
     });
     assert_eq!(sorted!(all_flag_variants), sorted!(all_features));
 }
+
+#[test]
+fn depkind_to_string() {
+    assert_eq!(DependencyKind::Normal.to_string(), "normal");
+    assert_eq!(DependencyKind::Development.to_string(), "dev");
+    assert_eq!(DependencyKind::Build.to_string(), "build");
+    assert_eq!(DependencyKind::Unknown.to_string(), "Unknown");
+}


### PR DESCRIPTION
This reuses the Serialize impl for consistency.

Fixes https://github.com/oli-obk/cargo_metadata/issues/156