### PR TITLE
add Metadata::workspace_packages method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,14 @@ impl Metadata {
         let root = self.resolve.as_ref()?.root.as_ref()?;
         self.packages.iter().find(|pkg| &pkg.id == root)
     }
+
+    /// Get the workspace packages.
+    pub fn workspace_packages(&self) -> Vec<&Package> {
+        self.packages
+            .iter()
+            .filter(|&p| self.workspace_members.contains(&p.id))
+            .collect()
+    }
 }
 
 impl<'a> std::ops::Index<&'a PackageId> for Metadata {

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -132,6 +132,10 @@ fn metadata_deps() {
 
     assert_eq!(this.name, "cargo_metadata");
 
+    let workspace_packages = metadata.workspace_packages();
+    assert_eq!(workspace_packages.len(), 1);
+    assert_eq!(&workspace_packages[0].id, this_id);
+
     let lib = this
         .targets
         .iter()


### PR DESCRIPTION
Inspired by [this](https://github.com/killercup/cargo-edit/blob/8a14de08c204e77374187f2d9348bae497803909/src/metadata.rs#L26) cargo-edit method, I thought it might be nice to have this functionality in this crate, directly.