### PR TITLE
Re-export semver::Prerelease and BuildMetadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ use std::process::Command;
 use std::str::from_utf8;
 
 pub use camino;
-pub use semver::{Version, VersionReq};
+pub use semver::{BuildMetadata, Prerelease, Version, VersionReq};
 
 pub use dependency::{Dependency, DependencyKind};
 use diagnostic::Diagnostic;


### PR DESCRIPTION
This makes it easier for the user of cargo_metadata to manipulate the
Version without having to add semver to their dependencies.
