### PR TITLE
Made edition an enum again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,8 +454,9 @@ pub struct Target {
 
 /// The Rust edition
 ///
-/// As of writing this comment rust editions 2024, 2027 and 2030 are not actually a thing yet but are here nonetheless for future proofing.
+/// As of writing this comment rust editions 2024, 2027 and 2030 are not actually a thing yet but are parsed nonetheless for future proofing.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum Edition {
     /// Edition 2015
     #[serde(rename = "2015")]
@@ -466,15 +467,15 @@ pub enum Edition {
     /// Edition 2021
     #[serde(rename = "2021")]
     E2021,
-    /// Edition 2024
+    #[doc(hidden)]
     #[serde(rename = "2024")]
-    E2024,
-    /// Edition 2027
+    _E2024,
+    #[doc(hidden)]
     #[serde(rename = "2027")]
-    E2027,
-    /// Edition 2030
+    _E2027,
+    #[doc(hidden)]
     #[serde(rename = "2030")]
-    E2030,
+    _E2030,
 }
 
 impl Default for Edition {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,28 +453,21 @@ pub struct Target {
 
 /// The Rust edition
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(transparent)]
-pub struct Edition(pub Cow<'static, str>);
-
-impl Edition {
-    /// Creates a new `Edition`.
-    pub fn new(edition: impl Into<Cow<'static, str>>) -> Self {
-        Self(edition.into())
-    }
-
-    /// Creates a new `Edition` from a static string.
-    pub const fn new_const(edition: &'static str) -> Self {
-        Self(Cow::Borrowed(edition))
-    }
-
-    /// Edition 2015.
-    pub const E2015: Self = Self::new_const("2015");
-
-    /// Edition 2018.
-    pub const E2018: Self = Self::new_const("2018");
-
-    /// Edition 2021.
-    pub const E2021: Self = Self::new_const("2021");
+pub enum Edition {
+    /// Edition 2015
+    #[serde(rename = "2015")]
+    E2015,
+    /// Edition 2018
+    #[serde(rename = "2018")]
+    E2018,
+    /// Edition 2021
+    #[serde(rename = "2021")]
+    E2021,
+    /// An unknown value was passed instead of a valid edition.
+    ///
+    /// This can mean one of two things. Either some corrupted data, or an edition not supported by the current crate version.
+    /// If you believe the latter is the case feel free to open an issue.
+    Unknown(Cow<'static, str>),
 }
 
 impl Default for Edition {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,3 +699,67 @@ impl MetadataCommand {
         Self::parse(stdout)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::{
+        borrow::Cow,
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    use crate::Edition;
+
+    // This test ensures that the manual implementation of PartialEq/Eq for the Edition enum are valid
+    #[test]
+    fn eq() {
+        assert_eq!(Edition::E2015, Edition::Unknown(Cow::Borrowed("2015")));
+        assert_eq!(Edition::E2018, Edition::Unknown(Cow::Borrowed("2018")));
+        assert_eq!(Edition::E2021, Edition::Unknown(Cow::Borrowed("2021")));
+        assert_ne!(Edition::E2015, Edition::Unknown(Cow::Borrowed("garbage")));
+        assert_ne!(
+            Edition::E2018,
+            Edition::Unknown(Cow::Borrowed("other garbage"))
+        );
+        assert_ne!(
+            Edition::E2021,
+            Edition::Unknown(Cow::Borrowed("final garbage"))
+        );
+    }
+
+    // This test ensures that the mannal implementation of Hash for the Edition enum is valid and that it upholds the following property
+    // k1 == k2 -> hash(k1) == hash(k2)
+    #[test]
+    fn eq_hash() {
+        fn calculate_hash<T: Hash>(t: &T) -> u64 {
+            let mut s = DefaultHasher::new();
+            t.hash(&mut s);
+            s.finish()
+        }
+
+        assert_eq!(
+            calculate_hash(&Edition::E2015),
+            calculate_hash(&Edition::Unknown(Cow::Borrowed("2015")))
+        );
+        assert_eq!(
+            calculate_hash(&Edition::E2018),
+            calculate_hash(&Edition::Unknown(Cow::Borrowed("2018")))
+        );
+        assert_eq!(
+            calculate_hash(&Edition::E2021),
+            calculate_hash(&Edition::Unknown(Cow::Borrowed("2021")))
+        );
+        assert_ne!(
+            calculate_hash(&Edition::E2015),
+            calculate_hash(&Edition::Unknown(Cow::Borrowed("garbage")))
+        );
+        assert_ne!(
+            calculate_hash(&Edition::E2018),
+            calculate_hash(&Edition::Unknown(Cow::Borrowed("other garbage")))
+        );
+        assert_ne!(
+            calculate_hash(&Edition::E2021),
+            calculate_hash(&Edition::Unknown(Cow::Borrowed("final garbage")))
+        );
+    }
+}


### PR DESCRIPTION
As mentioned in #183 this makes the Edition an enum again but also future proofs it by adding an `Unknown` variant