### PR TITLE
Ignore temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Cargo.lock
 .idea/
 target
+temp/
+tmp/


### PR DESCRIPTION
It is often useful to put temporary file in `tmp/` and `temp/` directories. This pull request simply adds those directories to the .gitignore file so that they aren't accidentally commited to the repo