### PR TITLE
Made camino an optional dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Made `parse_stream` more versatile by accepting anything that implements `Read`.
+- Made `camino` an optional dependency disabled by default.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 rust-version = "1.42.0"
 
 [dependencies]
-camino = { version = "1.0.7", features = ["serde1"] }
+camino = { version = "1.0.7", optional = true, features = ["serde1"] }
 cargo-platform = "0.1.2"
 derive_builder = { version = "0.11.1", optional = true }
 semver = { version = "1.0.7", features = ["serde"] }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -2,7 +2,11 @@
 
 use std::fmt;
 
+#[cfg(feature = "camino")]
 use camino::Utf8PathBuf;
+#[cfg(not(feature = "camino"))]
+use std::path::PathBuf as Utf8PathBuf;
+
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
 use semver::VersionReq;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,11 @@
 //! let output = command.wait().expect("Couldn't get cargo's exit status");
 //! ```
 
+#[cfg(feature = "camino")]
 use camino::Utf8PathBuf;
+#[cfg(not(feature = "camino"))]
+use std::path::PathBuf as Utf8PathBuf;
+
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
 use std::borrow::Cow;
@@ -90,6 +94,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str::from_utf8;
 
+#[cfg(feature = "camino")]
 pub use camino;
 pub use semver;
 use semver::{Version, VersionReq};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,5 +1,10 @@
 use super::{Diagnostic, PackageId, Target};
+
+#[cfg(feature = "camino")]
 use camino::Utf8PathBuf;
+#[cfg(not(feature = "camino"))]
+use std::path::PathBuf as Utf8PathBuf;
+
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -3,7 +3,11 @@ extern crate semver;
 #[macro_use]
 extern crate serde_json;
 
+#[cfg(feature = "camino")]
 use camino::Utf8PathBuf;
+#[cfg(not(feature = "camino"))]
+use std::path::PathBuf as Utf8PathBuf;
+
 use cargo_metadata::{CargoOpt, DependencyKind, Edition, Metadata, MetadataCommand};
 
 #[test]
@@ -93,13 +97,13 @@ fn old_minimal() {
     assert_eq!(target.kind, vec!["bin"]);
     assert_eq!(target.crate_types, vec!["bin"]);
     assert_eq!(target.required_features.len(), 0);
-    assert_eq!(target.src_path, "/foo/src/main.rs");
+    assert_eq!(target.src_path, Utf8PathBuf::from("/foo/src/main.rs"));
     assert_eq!(target.edition, Edition::E2015);
     assert!(target.doctest);
     assert!(target.test);
     assert!(target.doc);
     assert_eq!(pkg.features.len(), 0);
-    assert_eq!(pkg.manifest_path, "/foo/Cargo.toml");
+    assert_eq!(pkg.manifest_path, Utf8PathBuf::from("/foo/Cargo.toml"));
     assert_eq!(pkg.categories.len(), 0);
     assert_eq!(pkg.keywords.len(), 0);
     assert_eq!(pkg.readme, None);
@@ -116,9 +120,9 @@ fn old_minimal() {
         "foo 0.1.0 (path+file:///foo)"
     );
     assert!(meta.resolve.is_none());
-    assert_eq!(meta.workspace_root, "/foo");
+    assert_eq!(meta.workspace_root, Utf8PathBuf::from("/foo"));
     assert_eq!(meta.workspace_metadata, serde_json::Value::Null);
-    assert_eq!(meta.target_directory, "/foo/target");
+    assert_eq!(meta.target_directory, Utf8PathBuf::from("/foo/target"));
 }
 
 macro_rules! sorted {


### PR DESCRIPTION
As I already said in #193 I don't feel like camino is necessary however there might people that relay/need this kind of behavior so I made it an optional dependency disabled by default. I also updated the changelog with the corresponding entry.