### PR TITLE
Remove unused import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,6 @@
 use camino::Utf8PathBuf;
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
 use std::fmt;


### PR DESCRIPTION
There was an unused import causing a warning. This pull request just remove it.