### PR TITLE
Add `Edition::as_str()` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,6 +477,21 @@ pub enum Edition {
     _E2030,
 }
 
+impl Edition {
+    /// Return the string representation of the edition
+    pub fn as_str(&self) -> &'static str {
+        use Edition::*;
+        match self {
+            E2015 => "2015",
+            E2018 => "2018",
+            E2021 => "2021",
+            _E2024 => "2024",
+            _E2027 => "2027",
+            _E2030 => "2030",
+        }
+    }
+}
+
 impl Default for Edition {
     fn default() -> Self {
         Self::E2015

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,6 +492,12 @@ impl Edition {
     }
 }
 
+impl fmt::Display for Edition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl Default for Edition {
     fn default() -> Self {
         Self::E2015


### PR DESCRIPTION
In skeptic, I'd like to be able to pass an `Edition` in a command-line flag to rustc.

Could potentially also add a `fmt::Display` impl.