### PR TITLE
Fix `Package::readme()` to return correct path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,9 +375,12 @@ impl Package {
 
     /// Full path to the readme file if one is present in the manifest
     pub fn readme(&self) -> Option<Utf8PathBuf> {
-        self.readme
-            .as_ref()
-            .map(|file| self.manifest_path.join(file))
+        self.readme.as_ref().map(|file| {
+            self.manifest_path
+                .parent()
+                .unwrap_or(&self.manifest_path)
+                .join(file)
+        })
     }
 }
 

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -344,6 +344,7 @@ fn all_the_fields() {
     assert_eq!(all.categories, vec!["command-line-utilities"]);
     assert_eq!(all.keywords, vec!["cli"]);
     assert_eq!(all.readme, Some(Utf8PathBuf::from("README.md")));
+    assert!(all.readme().unwrap().ends_with("tests/all/README.md"));
     assert_eq!(
         all.repository,
         Some("https://github.com/oli-obk/cargo_metadata/".to_string())


### PR DESCRIPTION
fixes #201