### PR TITLE
reexport a few types from serde_json

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ use std::str::from_utf8;
 pub use camino;
 pub use semver;
 use semver::{Version, VersionReq};
+pub use serde_json::{Map, Number, Value};
 
 pub use dependency::{Dependency, DependencyKind};
 use diagnostic::Diagnostic;


### PR DESCRIPTION
Mostly to be able to consume Metadata::workspace_metadata without having to worry about depending on serde_json directly and keeping dependencies in sync.

Well, you can use methods on `Value` as is, but this gives you pattern matching.