### PR TITLE
Release via GitHub Actions, with semver-checking and git tag.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+    secrets:
+      CARGO_REGISTRY_TOKEN:
+        required: true
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: true
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Determine which version we're about to publish, so we can tag it appropriately.
+      # If the tag already exists, then we've already published this version.
+      - name: Determine current version
+        id: version-check
+        run: |
+          # Fail on first error, on undefined variables, and on errors in pipes.
+          set -euo pipefail
+          export VERSION="$(cargo metadata --format-version 1 | \
+            jq --arg crate_name cargo_metadata --exit-status -r \
+                '.packages[] | select(.name == $crate_name) | .version')"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$(git tag -l "$VERSION")" != '' ]]; then
+            echo "Aborting: Version $VERSION is already published, we found its tag in the repo."
+            exit 1
+          fi
+
+      # TODO: Replace this with the cargo-semver-checks v2 GitHub Action when it's stabilized:
+      #       https://github.com/obi1kenobi/cargo-semver-checks-action/pull/21
+      - name: Semver-check
+        run: |
+          # Fail on first error, on undefined variables, and on errors in pipes.
+          set -euo pipefail
+          cargo install --locked cargo-semver-checks
+          cargo semver-checks check-release
+
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Tag the version
+        run: |
+          # Fail on first error, on undefined variables, and on errors in pipes.
+          set -euo pipefail
+          git tag "${{ steps.version-check.outputs.version }}"
+          git push origin "${{ steps.version-check.outputs.version }}"
+
+      - uses: taiki-e/create-gh-release-action@v1
+        name: Create GitHub release
+        with:
+          branch: main
+          ref: refs/tags/${{ steps.version-check.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a [manually-triggered workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) for releasing a new version of `cargo_metadata`, complete with build caching, tagging, and cargo-semver-checks.

This uses a "bare" tag format like `0.15.2`, following the example of the most recent tags in the project. Some of the older tags use a `v`-prefixed tag name like `v0.13.0`; if that's a preferable format then I'd be happy to switch it.

It's also possible to make a workflow that is automatically triggered once `Cargo.toml` is updated with a new version on the `main` branch. This is how I generally configure my projects (e.g. [that's how `cargo-semver-checks` releases](https://github.com/obi1kenobi/cargo-semver-checks/blob/main/.github/workflows/release.yml)), but I wasn't sure if that would also be your preference so I went with a manual trigger instead.