### PR TITLE
Allow setting env vars in cargo_metadata command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,7 +710,11 @@ impl MetadataCommand {
     ///     // ...
     ///     # ;
     /// ```
-    pub fn env<K: Into<OsString>, V: Into<OsString>>(&mut self, key: K, val: V) -> &mut MetadataCommand {
+    pub fn env<K: Into<OsString>, V: Into<OsString>>(
+        &mut self,
+        key: K,
+        val: V,
+    ) -> &mut MetadataCommand {
         self.env.insert(key.into(), val.into());
         self
     }


### PR DESCRIPTION
Just like with `other_options`, this is a reasonably common use-case, and needing to re-implement `exec` just to pass an extra env var is a bit annoying.