### PR TITLE
Replace Travis badge with GitHub Actions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Also supports serialization to aid in implementing `--message-format=json`-like
 output generation in `cargo-*` subcommands, since some of the types in what
 `cargo --message-format=json` emits are exactly the same as the ones from `cargo metadata`.
 
-[![Build Status](https://api.travis-ci.org/oli-obk/cargo_metadata.svg?branch=master)](https://travis-ci.org/oli-obk/cargo_metadata)
+[![Build Status](https://github.com/oli-obk/cargo_metadata/workflows/CI/badge.svg?branch=main)](https://github.com/oli-obk/cargo_metadata/actions/workflows/main.yml?query=branch%3Amain)
 [![crates.io](https://img.shields.io/crates/v/cargo_metadata.svg)](https://crates.io/crates/cargo_metadata)
 
 [Documentation](https://docs.rs/cargo_metadata/)


### PR DESCRIPTION
Travis is dead since 2021: https://github.com/oli-obk/cargo_metadata/commit/fa404d73f248b02cf7c79c27e0bd99644360e57b