### PR TITLE
Use `v` prefix for version tags.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           # Fail on first error, on undefined variables, and on errors in pipes.
           set -euo pipefail
-          git tag "${{ steps.version-check.outputs.version }}"
+          git tag "v${{ steps.version-check.outputs.version }}"
           git push origin "${{ steps.version-check.outputs.version }}"
 
       - uses: taiki-e/create-gh-release-action@v1


### PR DESCRIPTION
I just noticed that the vast majority of version tags in this repo use the `v` prefix for version tags, but this workflow doesn't add that prefix right now.

Perhaps it's better to stay consistent as much as possible.