### PR TITLE
Explicitly depend on serde_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ camino = { version = "1.0.7", features = ["serde1"] }
 cargo-platform = "0.1.2"
 derive_builder = { version = "0.11.1", optional = true }
 semver = { version = "1.0.7", features = ["serde"] }
-serde = { version = "1.0.136", features = ["derive"] }
+serde = "1.0.136"
+serde_derive = "1.0.136"
 serde_json = { version = "1.0.79", features = ["unbounded_depth"] }
 thiserror = "1.0.31"
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -6,7 +6,8 @@ use camino::Utf8PathBuf;
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
 use semver::VersionReq;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::Deserializer;
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Eq, PartialEq, Clone, Debug, Copy, Hash, Serialize, Deserialize)]
 /// Dependencies can come in three kinds
@@ -44,7 +45,7 @@ pub(super) fn parse_dependency_kind<'de, D>(d: D) -> Result<DependencyKind, D::E
 where
     D: Deserializer<'de>,
 {
-    Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())
+    serde::Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 
 /// The error code associated to this diagnostic.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub use messages::{
     ArtifactBuilder, ArtifactProfileBuilder, BuildFinishedBuilder, BuildScriptBuilder,
     CompilerMessageBuilder,
 };
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 mod dependency;
 pub mod diagnostic;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -2,7 +2,8 @@ use super::{Diagnostic, PackageId, Target};
 use camino::Utf8PathBuf;
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize as _;
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 use std::io::{self, BufRead, Read};
 


### PR DESCRIPTION
This allows `serde` and `serde_derive` to build in parallel, improving compile times (once the same change happens in `camino` which this crate depends on), see https://github.com/rust-lang/rust-analyzer/pull/14450