### PR TITLE
Use `cargo-semver-checks-action` to run semver checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,10 @@ jobs:
         cargo test --verbose --no-default-features
         cargo test --verbose --all-features
 
-    # doesn't work right now
-    #- name: Check semver
-    #  uses: obi1kenobi/cargo-semver-checks-action@v1
+  semver-checks:
+    name: Check semver
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run cargo-semver-checks
+      uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
Hi! I'm one of the contributors of cargo-semver-checks. I noticed the use of `cargo-semver-checks-action` that is commented out in your CI.

Since we've recently released a new, completely rebuilt V2 version of the GitHub action, you can now conveniently use it in your workflow. It fixes the problems of outdated V1 and includes huge improvements of the running time. I suggested adding a job `semver-checks`, which seems to work well now. I hope it will be useful!