### PR TITLE
bump derive_builder dependency to v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "structured access to the output of `cargo metadata`"
 license = "MIT"
 readme = "README.md"
 edition = "2018"
-rust-version = "1.42.0"
+rust-version = "1.56.0"
 
 [dependencies]
 camino = { version = "1.0.7", features = ["serde1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.56.0"
 [dependencies]
 camino = { version = "1.0.7", features = ["serde1"] }
 cargo-platform = "0.1.2"
-derive_builder = { version = "0.11.1", optional = true }
+derive_builder = { version = "0.12", optional = true }
 semver = { version = "1.0.7", features = ["serde"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79", features = ["unbounded_depth"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@ impl MetadataCommand {
             .or_else(|| env::var("CARGO").map(PathBuf::from).ok())
             .unwrap_or_else(|| PathBuf::from("cargo"));
         let mut cmd = Command::new(cargo);
-        cmd.args(&["metadata", "--format-version", "1"]);
+        cmd.args(["metadata", "--format-version", "1"]);
 
         if self.no_deps {
             cmd.arg("--no-deps");


### PR DESCRIPTION
Version 0.12.0 of the `derive_builder` crate introduces only a small breaking change which does not affect this crate.

I have also bumped the MSRV of `cargo_metadata` to 1.56.0 - I tried compiling this crate with the currently set 1.42.0, which fails (even before bumping derive_builder to v0.12) because some of this crate's dependencies have moved to the Rust 2021 edition (which was stabilized in Rust 1.56.0).