### PR TITLE
fix!: change type of Package.rust_version to BareVersion

### DIFF
--- a/src/bare_version.rs
+++ b/src/bare_version.rs
@@ -1,0 +1,159 @@
+//! This module defines the [`BareVersion`] type used for `rust_version` in [`Package`](crate::Package).
+use std::{fmt::Display, num::ParseIntError, str::FromStr};
+
+use semver::Version;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A bare version number with two or three components (used for `rust_version` in [`Package`](crate::Package)).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BareVersion {
+    /// The major version component
+    pub major: u64,
+    /// The minor version component
+    pub minor: u64,
+    /// The patch version component
+    pub patch: Option<u64>,
+}
+
+impl Display for BareVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.patch {
+            Some(patch) => write!(f, "{}.{}.{}", self.major, self.minor, patch),
+            None => write!(f, "{}.{}", self.major, self.minor),
+        }
+    }
+}
+
+impl FromStr for BareVersion {
+    type Err = BareVersionError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let mut parts = s.splitn(3, '.');
+        Ok(Self {
+            major: parts
+                .next()
+                .filter(|s| !s.is_empty())
+                .ok_or(BareVersionError::Empty)?
+                .parse()?,
+            minor: parts
+                .next()
+                .filter(|s| !s.is_empty())
+                .ok_or(BareVersionError::ExpectedMinorVersion)?
+                .parse()?,
+            patch: parts.next().map(u64::from_str).transpose()?,
+        })
+    }
+}
+
+impl Serialize for BareVersion {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for BareVersion {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let string = String::deserialize(d)?;
+        string.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// An error while parsing a bare version.
+#[derive(Debug)]
+pub enum BareVersionError {
+    /// Value is empty.
+    Empty,
+    /// Value lacks a minor version.
+    ExpectedMinorVersion,
+    /// Failed to parse an integer.
+    ParseInt(ParseIntError),
+}
+
+impl Display for BareVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BareVersionError::Empty => write!(f, "value is empty"),
+            BareVersionError::ExpectedMinorVersion => write!(f, "expected a minor version"),
+            BareVersionError::ParseInt(err) => write!(f, "failed to parse integer: {err}"),
+        }
+    }
+}
+
+impl From<ParseIntError> for BareVersionError {
+    fn from(err: ParseIntError) -> Self {
+        Self::ParseInt(err)
+    }
+}
+
+// not used by this crate, just for the convenience of API users
+impl From<Version> for BareVersion {
+    fn from(value: Version) -> Self {
+        Self {
+            major: value.major,
+            minor: value.minor,
+            patch: Some(value.patch),
+        }
+    }
+}
+
+// not used by this crate, just for the convenience of API users
+impl From<BareVersion> for Version {
+    fn from(value: BareVersion) -> Self {
+        Self::new(value.major, value.minor, value.patch.unwrap_or(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::bare_version::BareVersionError;
+
+    use super::BareVersion;
+
+    #[test]
+    fn test_from_str() {
+        assert!(matches!(
+            BareVersion::from_str("1.2.3"),
+            Ok(BareVersion {
+                major: 1,
+                minor: 2,
+                patch: Some(3)
+            })
+        ));
+
+        assert!(matches!(
+            BareVersion::from_str("1.2"),
+            Ok(BareVersion {
+                major: 1,
+                minor: 2,
+                patch: None
+            })
+        ));
+
+        assert!(matches!(
+            BareVersion::from_str("1.2."),
+            Err(BareVersionError::ParseInt(..))
+        ));
+
+        assert!(matches!(
+            BareVersion::from_str("1."),
+            Err(BareVersionError::ExpectedMinorVersion)
+        ));
+
+        assert!(matches!(
+            BareVersion::from_str("1"),
+            Err(BareVersionError::ExpectedMinorVersion)
+        ));
+
+        assert!(matches!(
+            BareVersion::from_str(""),
+            Err(BareVersionError::Empty)
+        ));
+
+        assert!(matches!(
+            BareVersion::from_str(" "),
+            Err(BareVersionError::ParseInt(..))
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@
 //! let output = command.wait().expect("Couldn't get cargo's exit status");
 //! ```
 
+use bare_version::BareVersion;
 use camino::Utf8PathBuf;
 #[cfg(feature = "builder")]
 use derive_builder::Builder;
@@ -92,7 +93,7 @@ use std::str::from_utf8;
 
 pub use camino;
 pub use semver;
-use semver::{Version, VersionReq};
+use semver::Version;
 
 #[cfg(feature = "builder")]
 pub use dependency::DependencyBuilder;
@@ -112,6 +113,7 @@ pub use messages::{
 };
 use serde::{Deserialize, Serialize};
 
+pub mod bare_version;
 mod dependency;
 pub mod diagnostic;
 mod errors;
@@ -381,7 +383,7 @@ pub struct Package {
     /// The minimum supported Rust version of this package.
     ///
     /// This is always `None` if running with a version of Cargo older than 1.58.
-    pub rust_version: Option<VersionReq>,
+    pub rust_version: Option<BareVersion>,
 }
 
 impl Package {

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -210,10 +210,7 @@ fn all_the_fields() {
     assert_eq!(all.links, Some("foo".to_string()));
     assert_eq!(all.default_run, Some("otherbin".to_string()));
     if ver >= semver::Version::parse("1.58.0").unwrap() {
-        assert_eq!(
-            all.rust_version,
-            Some(semver::VersionReq::parse("1.56").unwrap())
-        );
+        assert_eq!(all.rust_version, Some("1.56".parse().unwrap()));
     }
 
     assert_eq!(all.dependencies.len(), 8);


### PR DESCRIPTION
As per the Cargo Book[1]:

> The Rust version must be a bare version number with two or three
> components; it cannot include semver operators or pre-release
> identifiers.

VersionReq therefore obviously is the wrong type since it describes[2]:

> the intersection of some version comparators such as `>=1.2.3, <1.8`

Since the semver crate apparently doesn't include a type for bare versions, this commit introduces a new such type. Prior art includes the cargo-msrv crate which already defines its own BareVersion type.[3] The type introduced by this commit differs in that it's a struct instead of an enum since that allows easier access to the major and minor numbers.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
[2]: https://docs.rs/semver/1.0.7/semver/struct.VersionReq.html
[3]: https://github.com/foresterre/cargo-msrv/blob/v0.15.1/src/manifest/bare_version.rs