### PR TITLE
Add `workspace_default_members` field

### DIFF
--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -135,9 +135,6 @@ fn metadata_deps() {
     let workspace_packages = metadata.workspace_packages();
     assert_eq!(workspace_packages.len(), 1);
     assert_eq!(&workspace_packages[0].id, this_id);
-    if let Some(default_packages) = metadata.workspace_default_packages() {
-        assert_eq!(default_packages, workspace_packages);
-    }
 
     let lib = this
         .targets
@@ -163,4 +160,21 @@ fn metadata_deps() {
     assert!(!serde.req.matches(&Version::parse("1.0.0").unwrap()));
     assert!(serde.req.matches(&Version::parse("1.99.99").unwrap()));
     assert!(!serde.req.matches(&Version::parse("2.0.0").unwrap()));
+}
+
+#[test]
+fn workspace_default_packages() {
+    use cargo_metadata::workspace_default_members_is_missing;
+
+    let metadata = MetadataCommand::new()
+        .manifest_path("Cargo.toml")
+        .exec()
+        .unwrap();
+    let workspace_packages = metadata.workspace_packages();
+    // this will only trigger on cargo versions that expose
+    // workspace_default_members (that is, cargo >= 1.71)
+    if !workspace_default_members_is_missing(&metadata.workspace_default_members) {
+        let default_packages = metadata.workspace_default_packages();
+        assert_eq!(default_packages, workspace_packages);
+    }
 }

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -5,19 +5,19 @@ extern crate serde_json;
 
 use camino::Utf8PathBuf;
 use cargo_metadata::{
-    ArtifactDebuginfo, CargoOpt, DependencyKind, Edition, Message, Metadata, MetadataCommand,
+    workspace_default_members_is_missing, ArtifactDebuginfo, CargoOpt, DependencyKind, Edition,
+    Message, Metadata, MetadataCommand,
 };
 
-#[test]
-fn old_minimal() {
-    // Output from oldest supported version (1.24).
-    // This intentionally has as many null fields as possible.
-    // 1.8 is when metadata was introduced.
-    // Older versions not supported because the following are required:
-    // - `workspace_members` added in 1.13
-    // - `target_directory` added in 1.19
-    // - `workspace_root` added in 1.24
-    let json = r#"
+/// Output from oldest version ever supported (1.24).
+///
+/// This intentionally has as many null fields as possible.
+/// 1.8 is when metadata was introduced.
+/// Older versions not supported because the following are required:
+/// - `workspace_members` added in 1.13
+/// - `target_directory` added in 1.19
+/// - `workspace_root` added in 1.24
+const JSON_OLD_MINIMAL: &str = r#"
 {
   "packages": [
     {
@@ -65,7 +65,10 @@ fn old_minimal() {
   "workspace_root": "/foo"
 }
 "#;
-    let meta: Metadata = serde_json::from_str(json).unwrap();
+
+#[test]
+fn old_minimal() {
+    let meta: Metadata = serde_json::from_str(JSON_OLD_MINIMAL).unwrap();
     assert_eq!(meta.packages.len(), 1);
     let pkg = &meta.packages[0];
     assert_eq!(pkg.name, "foo");
@@ -121,6 +124,15 @@ fn old_minimal() {
     assert_eq!(meta.workspace_root, "/foo");
     assert_eq!(meta.workspace_metadata, serde_json::Value::Null);
     assert_eq!(meta.target_directory, "/foo/target");
+
+    assert!(workspace_default_members_is_missing(
+        &meta.workspace_default_members
+    ));
+    let serialized = serde_json::to_value(meta).unwrap();
+    assert!(!serialized
+        .as_object()
+        .unwrap()
+        .contains_key("workspace_default_members"));
 }
 
 macro_rules! sorted {
@@ -188,7 +200,7 @@ fn all_the_fields() {
         .unwrap();
     assert_eq!(meta.workspace_root.file_name().unwrap(), "all");
     assert_eq!(
-        serde_json::from_value::<WorkspaceMetadata>(meta.workspace_metadata).unwrap(),
+        serde_json::from_value::<WorkspaceMetadata>(meta.workspace_metadata.clone()).unwrap(),
         WorkspaceMetadata {
             testobject: TestObject {
                 myvalue: "abc".to_string()
@@ -198,9 +210,7 @@ fn all_the_fields() {
     assert_eq!(meta.workspace_members.len(), 1);
     assert!(meta.workspace_members[0].to_string().starts_with("all"));
     if ver >= semver::Version::parse("1.71.0").unwrap() {
-        assert_eq!(meta.workspace_default_members, Some(meta.workspace_members));
-    } else {
-        assert_eq!(meta.workspace_default_members, None);
+        assert_eq!(&*meta.workspace_default_members, &meta.workspace_members);
     }
 
     assert_eq!(meta.packages.len(), 9);
@@ -456,6 +466,18 @@ fn all_the_fields() {
         kind.target.as_ref().map(|x| x.to_string()),
         Some("cfg(windows)".to_string())
     );
+
+    let serialized = serde_json::to_value(meta).unwrap();
+    if ver >= semver::Version::parse("1.71.0").unwrap() {
+        assert!(serialized.as_object().unwrap()["workspace_default_members"]
+            .as_array()
+            .is_some());
+    } else {
+        assert!(!serialized
+            .as_object()
+            .unwrap()
+            .contains_key("workspace_default_members"));
+    }
 }
 
 #[test]
@@ -695,4 +717,11 @@ fn debuginfo_variants() {
             _ => panic!("unexpected {:?}", message),
         }
     }
+}
+
+#[test]
+#[should_panic = "WorkspaceDefaultMembers should only be dereferenced on Cargo versions >= 1.71"]
+fn missing_workspace_default_members() {
+    let meta: Metadata = serde_json::from_str(JSON_OLD_MINIMAL).unwrap();
+    let _ = &*meta.workspace_default_members;
 }


### PR DESCRIPTION
Fixes #215

* Adding new field `workspace_default_members` which was added in Cargo 1.71. I made it an option because we have no way to reconstruct the value in previous Cargo versions.
* I also added a convenience method to collect `&Package`s that are default workspace members. But it also needs to either return an Option or panic. I'm not sure this is ideal, because at some point in the future the minimum supported Cargo version might be >=1.71 and changing this API would be a backwards incompatible change. But panicking doesn't feel ideal either. Should I remove this method?
* I did not want to bump the minimum version for the `all_the_fields` test. Instead I added a conditional assertion, following the same pattern introduced by the `rust_version` field.
* There are no tests that exercise this field other than "it should be the same as workspace_members". Should I add some test data?