### PR TITLE
Fix docs for `Target.kind` and `Target.crate_types`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ pub struct Target {
     /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
     /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`
     pub kind: Vec<String>,
-    /// Almost the same as `kind`, but only reports the
+    /// Similar to `kind`, but only reports the
     /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
     /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`.
     /// Everything that's not a proc macro or a library of some kind is reported as "bin".

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,14 +503,19 @@ pub struct Target {
     /// Name as given in the `Cargo.toml` or generated from the file name
     pub name: String,
     /// Kind of target.
+    ///
     /// The possible values are `example`, `test`, `bench`, `custom-build` and
     /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
-    /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`
+    /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`.
+    ///
+    /// Other possible values may be added in the future.
     pub kind: Vec<String>,
     /// Similar to `kind`, but only reports the
     /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
     /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`.
     /// Everything that's not a proc macro or a library of some kind is reported as "bin".
+    ///
+    /// Other possible values may be added in the future.
     #[serde(default)]
     #[cfg_attr(feature = "builder", builder(default))]
     pub crate_types: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ pub struct Target {
     /// Name as given in the `Cargo.toml` or generated from the file name
     pub name: String,
     /// Kind of target.
-    /// This can be one of `example`, `test`, `bench`, `custom-build` and/or one of the
+    /// The possible values are `example`, `test`, `bench`, `custom-build` and
     /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
     /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`
     pub kind: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,8 +507,10 @@ pub struct Target {
     /// and/or one of the [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
     /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`
     pub kind: Vec<String>,
-    /// Almost the same as `kind`, except when an example is a library instead of an executable.
-    /// In that case `crate_types` contains things like `rlib` and `dylib` while `kind` is `example`
+    /// Almost the same as `kind`, but only reports the
+    /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
+    /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`.
+    /// Everything that's not a proc macro or a library of some kind is reported as "bin".
     #[serde(default)]
     #[cfg_attr(feature = "builder", builder(default))]
     pub crate_types: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,8 +503,8 @@ pub struct Target {
     /// Name as given in the `Cargo.toml` or generated from the file name
     pub name: String,
     /// Kind of target.
-    /// This can be one of `example`, `test`, `bench`, `custom-build`
-    /// and/or one of the [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
+    /// This can be one of `example`, `test`, `bench`, `custom-build` and/or one of the
+    /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
     /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`
     pub kind: Vec<String>,
     /// Almost the same as `kind`, but only reports the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,10 @@ impl fmt::Display for Source {
 pub struct Target {
     /// Name as given in the `Cargo.toml` or generated from the file name
     pub name: String,
-    /// Kind of target ("bin", "example", "test", "bench", "lib", "custom-build")
+    /// Kind of target.
+    /// This can be one of `example`, `test`, `bench`, `custom-build`
+    /// and/or one of the [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
+    /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`
     pub kind: Vec<String>,
     /// Almost the same as `kind`, except when an example is a library instead of an executable.
     /// In that case `crate_types` contains things like `rlib` and `dylib` while `kind` is `example`


### PR DESCRIPTION
I only realized that far more values than documented are possible in the `Target.kind` fields after my code broke for end users.

This brings the crate doc commends in line with [the official documentation on `cargo metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html).

The docs for `kind` are based on both the `cargo metadata` documentation and my experiments, while the docs for `crate_types` are based on documentation alone.