### PR TITLE
Add `Target.is_proc_macro()` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,6 +577,11 @@ impl Target {
     pub fn is_custom_build(&self) -> bool {
         self.is_kind("custom-build")
     }
+
+    /// Return true if this target is of kind "proc-macro".
+    pub fn is_proc_macro(&self) -> bool {
+        self.is_kind("proc-macro")
+    }
 }
 
 /// The Rust edition


### PR DESCRIPTION
I needed it in https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/554 but I ended up hand-rolling it