### PR TITLE
use cargo_util_schemas::{PackageName, FeatureName}

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           - rust: stable
           - rust: beta
           - rust: nightly
-          - rust: 1.56.0
+          - rust: 1.75.0
     steps:
     - uses: actions/checkout@v2
     - name: Install rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "structured access to the output of `cargo metadata`"
 license = "MIT"
 readme = "README.md"
 edition = "2018"
-rust-version = "1.56.0"
+rust-version = "1.75.0"
 
 [dependencies]
 camino = { version = "1.0.7", features = ["serde1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.56.0"
 [dependencies]
 camino = { version = "1.0.7", features = ["serde1"] }
 cargo-platform = "0.1.2"
+cargo-util-schemas = "0.2.0"
 derive_builder = { version = "0.12", optional = true }
 semver = { version = "1.0.7", features = ["serde"] }
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,7 +304,7 @@ pub struct Node {
 pub struct NodeDep {
     /// The name of the dependency's library target.
     /// If the crate was renamed, it is the new name.
-    pub name: String, // TODO(aatifsyed): should this be PackageName?
+    pub name: PackageName,
     /// Package ID (opaque unique identifier)
     pub pkg: PackageId,
     /// The kinds of dependencies.
@@ -358,7 +358,8 @@ pub struct Package {
     pub id: PackageId,
     /// The source of the package, e.g.
     /// crates.io or `None` for local projects.
-    pub source: Option<Source>, // TODO(aatifsyed): should this be RegistryName?
+    // Note that this is NOT the same as cargo_util_schemas::RegistryName
+    pub source: Option<Source>,
     /// The [`description` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-description-field) as specified in the `Cargo.toml`
     pub description: Option<String>,
     /// List of dependencies of this particular package

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,7 +777,7 @@ pub enum CargoOpt {
     /// Run cargo with `--no-default-features`
     NoDefaultFeatures,
     /// Run cargo with `--features <FEATURES>`
-    SomeFeatures(Vec<FeatureName>),
+    SomeFeatures(Vec<String>),
 }
 
 /// A builder for configurating `cargo metadata` invocation.
@@ -877,9 +877,7 @@ impl MetadataCommand {
     /// ```
     pub fn features(&mut self, features: CargoOpt) -> &mut MetadataCommand {
         match features {
-            CargoOpt::SomeFeatures(features) => self
-                .features
-                .extend(features.into_iter().map(FeatureName::into_inner)),
+            CargoOpt::SomeFeatures(features) => self.features.extend(features),
             CargoOpt::NoDefaultFeatures => {
                 assert!(
                     !self.no_default_features,

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -17,7 +17,7 @@ fn metadata() {
     let metadata = MetadataCommand::new().no_deps().exec().unwrap();
 
     let this = &metadata.packages[0];
-    assert_eq!(this.name, "cargo_metadata");
+    assert_eq!(this.name.as_str(), "cargo_metadata");
     assert_eq!(this.targets.len(), 3);
 
     let lib = this
@@ -130,7 +130,7 @@ fn metadata_deps() {
         .expect("Did not find ourselves");
     let this = &metadata[this_id];
 
-    assert_eq!(this.name, "cargo_metadata");
+    assert_eq!(this.name.as_str(), "cargo_metadata");
 
     let workspace_packages = metadata.workspace_packages();
     assert_eq!(workspace_packages.len(), 1);

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -439,10 +439,10 @@ fn all_the_fields() {
         .unwrap();
     assert_eq!(all.dependencies.len(), 8);
     assert_eq!(all.deps.len(), 8);
-    let newname = all.deps.iter().find(|d| d.name == "newname").unwrap();
+    let newname = all.deps.iter().find(|d| &*d.name == "newname").unwrap();
     assert!(newname.pkg.to_string().contains("oldname"));
     // Note the underscore here.
-    let path_dep = all.deps.iter().find(|d| d.name == "path_dep").unwrap();
+    let path_dep = all.deps.iter().find(|d| &*d.name == "path_dep").unwrap();
     assert!(path_dep.pkg.to_string().contains("path-dep"));
     assert_eq!(path_dep.dep_kinds.len(), 1);
     let kind = &path_dep.dep_kinds[0];
@@ -452,7 +452,7 @@ fn all_the_fields() {
     let namedep = all
         .deps
         .iter()
-        .find(|d| d.name == "different_name")
+        .find(|d| &*d.name == "different_name")
         .unwrap();
     assert!(namedep.pkg.to_string().contains("namedep"));
     assert_eq!(
@@ -460,19 +460,19 @@ fn all_the_fields() {
         features!["bitflags", "default", "feat1"]
     );
 
-    let bdep = all.deps.iter().find(|d| d.name == "bdep").unwrap();
+    let bdep = all.deps.iter().find(|d| &*d.name == "bdep").unwrap();
     assert_eq!(bdep.dep_kinds.len(), 1);
     let kind = &bdep.dep_kinds[0];
     assert_eq!(kind.kind, DependencyKind::Build);
     assert!(kind.target.is_none());
 
-    let devdep = all.deps.iter().find(|d| d.name == "devdep").unwrap();
+    let devdep = all.deps.iter().find(|d| &*d.name == "devdep").unwrap();
     assert_eq!(devdep.dep_kinds.len(), 1);
     let kind = &devdep.dep_kinds[0];
     assert_eq!(kind.kind, DependencyKind::Development);
     assert!(kind.target.is_none());
 
-    let windep = all.deps.iter().find(|d| d.name == "windep").unwrap();
+    let windep = all.deps.iter().find(|d| &*d.name == "windep").unwrap();
     assert_eq!(windep.dep_kinds.len(), 1);
     let kind = &windep.dep_kinds[0];
     assert_eq!(kind.kind, DependencyKind::Normal);


### PR DESCRIPTION
Testing the waters for how you'd feel about this change

[cargo_metadata](https://docs.rs/cargo_metadata) has validated strings for these usecases.
- this would be a breaking change with a new public dependency
