### PR TITLE
Enable documentation of non-default features and feature gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ default = []
 builder = ["derive_builder"]
 unstable = []
 
+[package.metadata.docs.rs]
+all-features = true
+
 [package.metadata.cargo_metadata_test]
 some_field = true
 other_field = "foo"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 //! Structured access to the output of `cargo metadata` and `cargo --message-format=json`.
 //! Usually used from within a `cargo-*` executable

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -37,7 +37,8 @@ fn metadata() {
         .metadata
         .as_object()
         .expect("package.metadata must be a table.");
-    assert_eq!(package_metadata.len(), 1);
+    // The second field is docs.rs metadata, ignore it
+    assert_eq!(package_metadata.len(), 2);
 
     let value = package_metadata.get("cargo_metadata_test").unwrap();
     let test_package_metadata: TestPackageMetadata = serde_json::from_value(value.clone()).unwrap();


### PR DESCRIPTION
I saw some cargo features but haven't find any documentation for those. This PR would become helpful in such situations.

Uses [`doc_auto_cfg`](https://github.com/rust-lang/rust/issues/43781) to generate documentation for feature gates (which is [used by bevy](https://github.com/bevyengine/bevy/pull/12366)). See about how to customize docs.rs build [here](https://docs.rs/about/builds).