### PR TITLE
Implement `ops::Index` with `PackageId` for `Resolve` graph

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl Metadata {
 impl<'a> std::ops::Index<&'a PackageId> for Metadata {
     type Output = Package;
 
-    fn index(&self, idx: &'a PackageId) -> &Package {
+    fn index(&self, idx: &'a PackageId) -> &Self::Output {
         self.packages
             .iter()
             .find(|p| p.id == *idx)
@@ -270,6 +270,17 @@ pub struct Resolve {
 
     /// The crate for which the metadata was read.
     pub root: Option<PackageId>,
+}
+
+impl<'a> std::ops::Index<&'a PackageId> for Resolve {
+    type Output = Node;
+
+    fn index(&self, idx: &'a PackageId) -> &Self::Output {
+        self.nodes
+            .iter()
+            .find(|p| p.id == *idx)
+            .unwrap_or_else(|| panic!("no Node with this id: {:?}", idx))
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
While iterating through dependency packages, I find myself needing to look up dependency nodes recursively through the graph, in the same way that I need `Package` information for its `PackageId` via the already-existing `ops::Index` implementation on `Metadata`.  This is simpler if the indexing operation is also available on a `Resolve`d graph.
