### PR TITLE
Make `cargo-platform` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.73.0"
 
 [dependencies]
 camino = { version = "1.0.7", features = ["serde1"] }
-cargo-platform = "0.1.2"
+cargo-platform = { version = "0.1.2", optional = true }
 derive_builder = { version = "0.12", optional = true }
 semver = { version = "1.0.7", features = ["serde"] }
 serde = { version = "1.0.136", features = ["derive"] }
@@ -21,6 +21,7 @@ thiserror = "1.0.31"
 [features]
 default = []
 builder = ["derive_builder"]
+platform = ["dep:cargo-platform"]
 unstable = []
 
 [package.metadata.cargo_metadata_test]

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -8,6 +8,11 @@ use derive_builder::Builder;
 use semver::VersionReq;
 use serde::{Deserialize, Deserializer, Serialize};
 
+#[cfg(feature = "platform")]
+pub use cargo_platform::Platform;
+#[cfg(not(feature = "platform"))]
+pub type Platform = String;
+
 #[derive(Eq, PartialEq, Clone, Debug, Copy, Hash, Serialize, Deserialize, Default)]
 /// Dependencies can come in three kinds
 pub enum DependencyKind {
@@ -81,5 +86,3 @@ pub struct Dependency {
     /// Only produced on cargo 1.51+
     pub path: Option<Utf8PathBuf>,
 }
-
-pub use cargo_platform::Platform;


### PR DESCRIPTION
This makes `cargo-platform` optional.

When deserializing, the original string is completely lost which can be problematic if the original string is desired, rather than the "prettified" version, and also means that an additional heap allocation is required if using a different cfg parser like https://crates.io/crates/cfg-expr.

I've added it as the `platform` feature and made it non-default so that users need to opt-in if they still want to use `cargo-platform`, rather than making it default and then needing every crate that doesn't use it to require an opt-out.