### PR TITLE
fix(Metadata): add `#[serde(default)]` on workspace_default_members field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub struct Metadata {
     /// The list of default workspace members
     ///
     /// This not available if running with a version of Cargo older than 1.71.
-    #[serde(skip_serializing_if = "workspace_default_members_is_missing")]
+    #[serde(default, skip_serializing_if = "workspace_default_members_is_missing")]
     pub workspace_default_members: WorkspaceDefaultMembers,
     /// Dependencies graph
     pub resolve: Option<Resolve>,
@@ -224,7 +224,7 @@ impl<'a> std::ops::Index<&'a PackageId> for Metadata {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Default)]
 #[serde(transparent)]
 /// A list of default workspace members.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,6 +728,7 @@ impl fmt::Display for TargetKind {
 
 /// Similar to `kind`, but only reports the
 /// [Cargo crate types](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field):
+///
 /// `bin`, `lib`, `rlib`, `dylib`, `cdylib`, `staticlib`, `proc-macro`.
 /// Everything that's not a proc macro or a library of some kind is reported as "bin".
 ///


### PR DESCRIPTION
Set a default value when Metadata is deserialized with WorkspaceDefaultMembers skipped in serialization.