### PR TITLE
Prepare release of v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,45 @@
 
 ## Unreleased
 
-- Bumped MSRV from `1.42.0` to `1.56.0`.
+- n/a
+
+### Added
+
+- n/a
+
+### Changed
+
+-n/a
+
+### Removed
+
+- n/a
+
+### Fixed
+
+- n/a
+
+## [0.19.0] - 2024-11-20
 
 ### Added
 
 - Re-exported `semver` crate directly.
+- Added implementation of `std::ops::Index<&PackageId>` for `Resolve`.
+- Added `pub fn is_kind(&self, name: TargetKind) -> bool` to `Target`.
+- Added derived implementations of `PartialEq`, `Eq` and `Hash` for `Metadata` and its members' types.
+- Added default fields to `PackageBuilder`.
+- Added `pub fn new(name:version:id:path:) -> Self` to `PackageBuilder` for providing all required fields upfront.
 
 ### Changed
 
+- Bumped MSRV from `1.42.0` to `1.56.0`.
 - Made `parse_stream` more versatile by accepting anything that implements `Read`.
 - Converted `TargetKind` and `CrateType` to an enum representation.
 
 ### Removed
 
 - Removed re-exports for `BuildMetadata` and `Prerelease` from `semver` crate.
+- Removed `.is_lib(…)`, `.is_bin(…)`, `.is_example(…)`, `.is_test(…)`, `.is_bench(…)`, `.is_custom_build(…)`, and `.is_proc_macro(…)` from `Target` (in favor of adding `.is_kind(…)`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Changed
 
--n/a
+- n/a
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 repository = "https://github.com/oli-obk/cargo_metadata"
 description = "structured access to the output of `cargo metadata`"


### PR DESCRIPTION
@oli-obk I've gone through the latest commits and added any missing changes to the `CHANGELOG.md` file and bumped the version from `0.18.1` to `0.19.0` due to the included bump of MSRV.

Lemme know if I missed anything here for a release.