### PR TITLE
Make `Dependency`'s `source` member the same type as `Package`'s `source` member: `Option<Source>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Updated dependencies:
   - `thiserror` from `1.0.31` to `2.0.3`
   - `derive_builder` from `0.12` to `0.20`
+- Made `Dependency`'s `source` member the same type as `Package`'s `source` member: `Option<Source>`.
 
 ### Removed
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -8,6 +8,8 @@ use derive_builder::Builder;
 use semver::VersionReq;
 use serde::{Deserialize, Deserializer, Serialize};
 
+use crate::Source;
+
 #[derive(Eq, PartialEq, Clone, Debug, Copy, Hash, Serialize, Deserialize, Default)]
 /// Dependencies can come in three kinds
 pub enum DependencyKind {
@@ -51,7 +53,7 @@ pub struct Dependency {
     /// Name as given in the `Cargo.toml`
     pub name: String,
     /// The source of dependency
-    pub source: Option<String>,
+    pub source: Option<Source>,
     /// The required version
     pub req: VersionReq,
     /// The kind of dependency this is

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -6,6 +6,7 @@ extern crate serde_json;
 use camino::Utf8PathBuf;
 use cargo_metadata::{
     ArtifactDebuginfo, CargoOpt, DependencyKind, Edition, Message, Metadata, MetadataCommand,
+    Source,
 };
 
 /// Output from oldest version ever supported (1.24).
@@ -239,7 +240,9 @@ fn all_the_fields() {
         .unwrap();
     assert_eq!(
         bitflags.source,
-        Some("registry+https://github.com/rust-lang/crates.io-index".to_string())
+        Some(Source {
+            repr: "registry+https://github.com/rust-lang/crates.io-index".to_string()
+        })
     );
     assert!(bitflags.optional);
     assert_eq!(bitflags.req, semver::VersionReq::parse("^1.0").unwrap());


### PR DESCRIPTION
They have the exact same representation (i.e. bare string) in the JSON output of `cargo metadata`, so might as well use the same type in `Metadata`.