### PR TITLE
build: fix -Zminimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo-platform = "0.1.2"
 derive_builder = { version = "0.20", optional = true }
 semver = { version = "1.0.7", features = ["serde"] }
 serde = { version = "1.0.136", features = ["derive"] }
-serde_json = { version = "1.0.79", features = ["unbounded_depth"] }
+serde_json = { version = "1.0.118", features = ["unbounded_depth"] }
 thiserror = "2.0.3"
 
 [features]


### PR DESCRIPTION
`serde_json::Value` started implementing `Hash` starting from v1.0.118