### PR TITLE
Version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 repository = "https://github.com/oli-obk/cargo_metadata"
 description = "structured access to the output of `cargo metadata`"


### PR DESCRIPTION
Bumps the patch version as requested in https://github.com/oli-obk/cargo_metadata/pull/284#issuecomment-2688912084.