### PR TITLE
feat: Added unstable build-dir support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,11 @@ jobs:
         cargo build --verbose --no-default-features
         cargo test --verbose
         cargo test --verbose --no-default-features
-        cargo test --verbose --all-features
+
+        # Test with all features. But do not use the `unstable` feature on non-nightly toolchains
+        if [ "${{ matrix.rust }}" = "nightly" ]; then
+          cargo test --verbose --all-features
+        else
+          ALL_FEATURES_EXCEPT_UNSTABLE=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].features | keys | .[]' | grep -v 'unstable' | tr '\n' ' ')
+          cargo test --features "$ALL_FEATURES_EXCEPT_UNSTABLE"
+        fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,14 @@ pub struct Metadata {
     pub resolve: Option<Resolve>,
     /// Workspace root
     pub workspace_root: Utf8PathBuf,
-    /// Build directory
+    /// Target directory
     pub target_directory: Utf8PathBuf,
+    /// Build directory
+    ///
+    /// Only populated if `-Zbuild-dir` is passed via .other_options()
+    // TODO: This should become non optional once cargo build-dir is stablized: https://github.com/rust-lang/cargo/issues/14125
+    #[cfg(feature = "unstable")]
+    pub build_directory: Option<Utf8PathBuf>,
     /// The workspace-level metadata object. Null if non-existent.
     #[serde(rename = "metadata", default, skip_serializing_if = "is_null")]
     pub workspace_metadata: serde_json::Value,

--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -177,3 +177,19 @@ fn workspace_default_packages() {
         assert_eq!(default_packages, workspace_packages);
     }
 }
+
+#[test]
+#[cfg(feature = "unstable")]
+fn build_dir() {
+    let metadata = MetadataCommand::new()
+        .no_deps()
+        .other_options(["-Zbuild-dir"].map(str::to_string))
+        .exec()
+        .unwrap();
+
+    assert!(&metadata.build_directory.is_some());
+    assert!(&metadata
+        .build_directory
+        .unwrap()
+        .ends_with("cargo_metadata/target"));
+}


### PR DESCRIPTION
This PR adds Cargo `build-dir` support behind the `unstable` crate flag.

I also modified the CI script to only use the `unstable` crate flag when using nightly. 

closes #296