### PR TITLE
Re-export PackageName from cargo-util-schemas

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,8 @@ pub use camino;
 pub use semver;
 use semver::Version;
 
-use cargo_util_schemas::manifest::{FeatureName, PackageName};
+pub use cargo_util_schemas::manifest::{FeatureName, PackageName};
+
 #[cfg(feature = "builder")]
 pub use dependency::DependencyBuilder;
 pub use dependency::{Dependency, DependencyKind};


### PR DESCRIPTION
This crate already exposes `PackageName` from cargo-util-schemas, but the type can't be named without also importing the cargo-util-schemas crate.

This PR re-exports the `PackageName`, so that users don't have to include cargo-util-schemas themselves, and hopefully it will be easier to upgrade it in the future.

BTW: currently cargo-util-schemas version used is 0.2, but the latest is 0.8, and 0.7 is the latest MSRV-compatible one.