### PR TITLE
fixes "package name cannot be empty" under "resolve/nodes/deps/name"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ pub struct Node {
 pub struct NodeDep {
     /// The name of the dependency's library target.
     /// If the crate was renamed, it is the new name.
-    pub name: PackageName,
+    pub name: String,
     /// Package ID (opaque unique identifier)
     pub pkg: PackageId,
     /// The kinds of dependencies.


### PR DESCRIPTION
When using "-Z bindeps" with locally referenced "build-dependencies" the "name" field is an empty string. PackageName reqires a non-empty string. Cargo's cargo_output_metadata.rs Dep struct's "name" field is defined as "InternedString" which does not have this restriction.

Fixes https://github.com/rust-lang/rust-analyzer/issues/20002