### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 ### Added
 
+- n/a
+
+### Changed
+
+- n/a
+
+### Removed
+
+- n/a
+
+### Fixed
+
+- n/a
+
+## [0.22.0] - TBD
+
+### Added
+
 - Added `pub fn env_remove<K: Into<OsString>>(&mut self, key: K) -> &mut MetadataCommand` to `MetadataCommand`.
 - Added export of `cargo_platform` at crate's root module.
 
@@ -20,14 +38,6 @@
   - `serde` from `1.0.136` to `1.0.219`
   - `thiserror` from `2.0.3` to `2.0.12`
 - Made `Dependency`'s `source` member the same type as `Package`'s `source` member: `Option<Source>`.
-
-### Removed
-
-- n/a
-
-### Fixed
-
-- n/a
 
 ## [0.19.0] - 2024-11-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_metadata"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 repository = "https://github.com/oli-obk/cargo_metadata"
 description = "structured access to the output of `cargo metadata`"


### PR DESCRIPTION
(The bump of `cargo_platform` from `"0.2.0"` to `"0.3.0"` is strictly speaking a breaking change.)

---

@oli-obk A new release (along with #302) would be greatly appreciated! 🙏  Lemme know if there's any way I can help with this, if your spare time is limited right now.