### PR TITLE
Add newtype wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.86.0"
 [dependencies]
 camino = { version = "1.1.10", features = ["serde1"] }
 cargo-platform = "0.3.0"
-cargo-util-schemas = "0.8.2"
 derive_builder = { version = "0.20", optional = true }
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/tests/test_samples.rs
+++ b/tests/test_samples.rs
@@ -5,10 +5,9 @@ extern crate serde_json;
 
 use camino::Utf8PathBuf;
 use cargo_metadata::{
-    ArtifactDebuginfo, CargoOpt, DependencyKind, Edition, Message, Metadata, MetadataCommand,
-    Source,
+    ArtifactDebuginfo, CargoOpt, DependencyKind, Edition, FeatureName, Message, Metadata,
+    MetadataCommand, Source,
 };
-use cargo_util_schemas::manifest::FeatureName;
 
 /// Output from oldest version ever supported (1.24).
 ///
@@ -147,7 +146,7 @@ macro_rules! sorted {
 macro_rules! features {
     ($($feat:expr),* $(,)?) => {
         ::std::vec![
-            $(::cargo_util_schemas::manifest::FeatureName::new(String::from($feat)).unwrap()),*
+            $(FeatureName::new(String::from($feat))),*
         ]
     };
 }


### PR DESCRIPTION
Adds a `str_newtype` macro (similar to [cargo-util-schema's](https://github.com/epage/cargo/blob/d8975d2901e132c02b3f6b1d107f2f50b275a058/crates/cargo-util-schemas/src/manifest/mod.rs#L1355-L1413)) and eliminates cargo-util-schema as a dependency.

These changes were discussed in https://github.com/oli-obk/cargo_metadata/issues/63#issuecomment-2911517148 and https://github.com/oli-obk/cargo_metadata/issues/294#issuecomment-3182993049.

If it is helpful, below are two screenshots of diffs between cargo-util-schema's `str_newtype` at commit `d8975d2` and the one introduced in this PR.

<img width="1868" height="1006" alt="Screenshot From 2025-08-18 20-47-34" src="https://github.com/user-attachments/assets/91e41635-9012-4e26-a144-7dc409947120" />
<img width="1868" height="911" alt="Screenshot From 2025-08-18 20-47-10" src="https://github.com/user-attachments/assets/29fa6e7e-9ef9-4f64-8e0a-da69462f686d" />
