### PR TITLE
Proposed `-Zbuild-dir` fix

### DIFF
--- a/tests/selftest.rs
+++ b/tests/selftest.rs
@@ -84,11 +84,13 @@ fn builder_interface() {
 
 #[test]
 fn error1() {
+    let manifest_path = current_dir().unwrap().join("foo");
+    let error = "error: the manifest-path must be a path to a Cargo.toml file";
+    let error_with_path = format!("{error}: `{}`", manifest_path.display());
     match MetadataCommand::new().manifest_path("foo").exec() {
-        Err(Error::CargoMetadata { stderr }) => assert_eq!(
-            stderr.trim(),
-            "error: the manifest-path must be a path to a Cargo.toml file"
-        ),
+        Err(Error::CargoMetadata { stderr }) => {
+            assert!([error, &error_with_path].contains(&stderr.trim()))
+        }
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
This is my proposed fix for the recent nightly breakage (https://github.com/rust-lang/cargo/commit/2b71fd6424de387502b37556c9fb00f657c70c78).

If I understand correctly, `-Zbuild-dir` is not yet in the stable version of Cargo, but it has been stabilized in the nightly version of Cargo.

CC @ranger-ross, who I think introduced the `build_dir` and `build_dir_disabled` tests.