### PR TITLE
Fix `cargo_metadata` not building on docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 //! Structured access to the output of `cargo metadata` and `cargo --message-format=json`.
 //! Usually used from within a `cargo-*` executable


### PR DESCRIPTION
`doc_auto_cfg` was merged into `doc_cfg`, so the old name is no longer accepted, which is why `cargo_metadata` [was failing to build on docs.rs](https://docs.rs/crate/cargo_metadata/0.23.0/builds/2546094). I believe this change was made in part because [the RFC](https://github.com/rust-lang/rfcs/blob/master/text/3631-rustdoc-cfgs-handling.md) was accepted.

Fixes #308.