### PR TITLE
refactor: allow for more flexible options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,8 +1118,11 @@ impl MetadataCommand {
     }
     /// Arbitrary command line flags to pass to `cargo`.  These will be added
     /// to the end of the command line invocation.
-    pub fn other_options(&mut self, options: impl Into<Vec<String>>) -> &mut MetadataCommand {
-        self.other_options = options.into();
+    pub fn other_options(
+        &mut self,
+        options: impl IntoIterator<Item: Into<String>>,
+    ) -> &mut MetadataCommand {
+        self.other_options = options.into_iter().map(Into::into).collect();
         self
     }
 


### PR DESCRIPTION
The prior signature for the `other_options()` method on `MetadataCommand` made for some slightly awkward conversions that required possibly using an iterator, followed by a `map()` at call site if say, you had `&str`s instead of `String`s. This PR tries to move that out of user code into the library, so as to allow the following,

```rust
let workspace_metadata = MetadataCommand::new()
    .no_deps()
    .other_options(["--format-version=1"]);
```

instead of (possibly, it's just one way)

```rust
let workspace_metadata = MetadataCommand::new()
    .no_deps()
    .other_options([String::from("--format-version=1")]);
```

or

```rust
let workspace_metadata = MetadataCommand::new()
    .no_deps()
    .other_options(["--format-version=1"].into_iter().map(ToString::to_string).collect());
```